### PR TITLE
Enable 'service_offerings/order' endpoint to launch job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'sources-api-client',              '~> 1.0'
 
 group :development, :test do
   gem "byebug", :platform => :mri
+  gem 'climate_control'
   gem "rubocop",             "~> 1.0.0", :require => false
   gem "rubocop-performance", "~> 1.8",   :require => false
   gem "rubocop-rails",       "~> 2.8",   :require => false
@@ -28,5 +29,8 @@ group :development, :test do
 end
 
 group :test do
+  gem 'factory_bot_rails'
+  gem 'faker'
   gem 'rspec-rails', '~>3.8'
+  gem 'shoulda-matchers', '~> 3.1'
 end

--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -28,7 +28,7 @@ module Api
 
         task_opts = {:name => "ServiceOffering##{operation_type}", :source_id => service_offering.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_offering.tenant, :state => "pending", :status => "ok"}
 
-        task = operation_type.to_s == "order" ? LaunchJobTaskService.new(params).process.task : Task.create!(task_opts)
+        task = operation_type.to_s == "order" ? LaunchJobTaskService.new(params.to_unsafe_h).process.task : Task.create!(task_opts)
         
         task.dispatch
 

--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -25,7 +25,13 @@ module Api
 
         source_type = retrieve_source_type(service_offering)
         logger.info("ServiceOffering##{operation_type}: Retrieved SourceType(id: #{source_type.id}, name: #{source_type.name}), ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref})")
-        task = Task.create!(:name => "ServiceOffering##{operation_type}", :source_id => service_offering.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_offering.tenant, :state => "pending", :status => "ok")
+
+        task_opts = {:name => "ServiceOffering##{operation_type}", :source_id => service_offering.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_offering.tenant, :state => "pending", :status => "ok"}
+
+        task = operation_type.to_s == "order" ? LaunchJobTaskService.new(params).process.task : Task.create!(task_opts)
+        
+        task.dispatch
+
         logger.info("ServiceOffering##{operation_type}: ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Task(id: #{task.id}) created.")
 
         payload = send("payload_for_#{operation_type}".to_sym, task, service_offering)

--- a/app/models/catalog_api_task.rb
+++ b/app/models/catalog_api_task.rb
@@ -1,5 +1,2 @@
 class CatalogApiTask < Task
-  def initialize
-    super
-  end
 end

--- a/app/models/check_availability_task.rb
+++ b/app/models/check_availability_task.rb
@@ -1,5 +1,2 @@
 class CheckAvailabilityTask < MqttClientTask
-  def initialize
-    super
-  end
 end

--- a/app/models/full_inventory_commit_task.rb
+++ b/app/models/full_inventory_commit_task.rb
@@ -1,5 +1,0 @@
-class FullInventoryCommitTask < KafkaMessageTask
-  def initialize
-    super
-  end
-end

--- a/app/models/full_inventory_upload_task.rb
+++ b/app/models/full_inventory_upload_task.rb
@@ -1,5 +1,0 @@
-class FullInventoryUploadTask < MqttClientTask
-  def initialize
-    super
-  end
-end

--- a/app/models/full_refresh_persister_task.rb
+++ b/app/models/full_refresh_persister_task.rb
@@ -1,0 +1,2 @@
+class FullRefreshPersisterTask < KafkaMessageTask
+end

--- a/app/models/full_refresh_upload_task.rb
+++ b/app/models/full_refresh_upload_task.rb
@@ -1,0 +1,2 @@
+class FullRefreshUploadTask < MqttClientTask
+end

--- a/app/models/incre_inventory_commit_task.rb
+++ b/app/models/incre_inventory_commit_task.rb
@@ -1,5 +1,0 @@
-class IncreInventoryCommitTask < KafkaMessageTask
-  def initialize
-    super
-  end
-end

--- a/app/models/incre_inventory_upload_task.rb
+++ b/app/models/incre_inventory_upload_task.rb
@@ -1,5 +1,0 @@
-class IncreInventoryUploadTask < MqttClientTask
-  def initialize
-    super
-  end
-end

--- a/app/models/incremental_refresh_persister_task.rb
+++ b/app/models/incremental_refresh_persister_task.rb
@@ -1,0 +1,2 @@
+class IncrementalRefreshPersisterTask < KafkaMessageTask
+end

--- a/app/models/incremental_refresh_upload_task.rb
+++ b/app/models/incremental_refresh_upload_task.rb
@@ -1,0 +1,2 @@
+class IncrementalRefreshUploadTask < MqttClientTask
+end

--- a/app/models/kafka_message_task.rb
+++ b/app/models/kafka_message_task.rb
@@ -1,5 +1,2 @@
 class KafkaMessageTask < Task
-  def initialize
-    super
-  end
 end

--- a/app/models/lanuch_tower_job_task.rb
+++ b/app/models/lanuch_tower_job_task.rb
@@ -1,5 +1,0 @@
-class LanuchTowerJobTask < MqttClientTask
-  def initialize
-    super
-  end
-end

--- a/app/models/launch_job_task.rb
+++ b/app/models/launch_job_task.rb
@@ -1,0 +1,7 @@
+class LaunchJobTask < MqttClientTask
+  # Post task to MQTT Controller
+  def dispatch
+    # TODO: create MQTT controller service
+    # MQTTController.dispatch(input)
+  end
+end

--- a/app/models/launch_job_task.rb
+++ b/app/models/launch_job_task.rb
@@ -1,7 +1,34 @@
 class LaunchJobTask < MqttClientTask
-  # Post task to MQTT Controller
-  def dispatch
-    # TODO: create MQTT controller service
-    # MQTTController.dispatch(input)
+  def service_options
+    {}.tap do |options|
+      options[:tenant_id] = tenant.id
+      options[:source_id] = source.id
+      options[:service_offering_id] = service_offering_id.to_s
+      options[:service_plan_id] = service_plan_id.to_s
+      options[:external_url] = output["url"]
+      options[:source_ref] = output["id"]
+      options[:name] = output["name"]
+      options[:description] = output["description"]
+      options[:source_created_at] = output["created"]
+      options[:extra] = extra
+    end
+  end
+
+  def extra
+    {}.tap do |e|
+      e[:status] = output["status"]
+      e[:started] = output["started"]
+      e[:finished] = output["finished"]
+      e[:extra_vars] = output["extra_vars"]
+      e[:artifacts] = output["artifacts"]
+    end
+  end
+
+  def service_offering_id
+    @service_offering_id ||= ServiceOffering.find_by(:source_ref => output["unified_job_template"].to_s).id
+  end
+
+  def service_plan_id
+    ServiceOffering.find(service_offering_id).service_plans.first.id
   end
 end

--- a/app/models/mqtt_client_task.rb
+++ b/app/models/mqtt_client_task.rb
@@ -1,2 +1,11 @@
 class MqttClientTask < Task
+  def dispatch
+    opts = {:task_id          => id,
+            :task_url         => "http://localhost:5000/api/catalog-inventory/v3.0/tasks",
+            # TODO: source.mqtt_client_guid
+            :mqtt_client_guid => "123456789",
+            :mqtt_client_url  => "mqtt://localhost:1883"}
+
+    MQTTControllerService.new(opts).process
+  end
 end

--- a/app/models/mqtt_client_task.rb
+++ b/app/models/mqtt_client_task.rb
@@ -1,11 +1,2 @@
 class MqttClientTask < Task
-
-  def initialize(payload)
-    super
-    @payload = payload
-    @input = payload.to_json
-  end
-
-  def dispatch
-  end
 end

--- a/app/models/return_order_task.rb
+++ b/app/models/return_order_task.rb
@@ -1,5 +1,2 @@
 class ReturnOrderTask < CatalogApiTask
-  def initialize
-    super
-  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -10,10 +10,10 @@ class Task < ApplicationRecord
   after_update :post_launch_job_task, :if => proc { type == 'LaunchJobTask' && state == 'completed' }
 
   def post_launch_job_task
-    # TODO: populate opt
-    opts = {:tenant_id => tenant.id, :source_id => source.id, :source_ref => SecureRandom.uuid}
+    PostLaunchJobTaskService.new(service_options).process
+  end
 
-    PostLaunchJobTaskService.new(opts).process
+  def service_options
   end
 
   def dispatch

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,4 +6,7 @@ class Task < ApplicationRecord
   validates :status, :inclusion => {:in => %w(ok warn error)}
 
   acts_as_tenant(:tenant)
+
+  def dispatch
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,15 @@ class Task < ApplicationRecord
 
   acts_as_tenant(:tenant)
 
+  after_update :post_launch_job_task, :if => proc { type == 'LaunchJobTask' && state == 'completed' }
+
+  def post_launch_job_task
+    # TODO: populate opt
+    opts = {:tenant_id => tenant.id, :source_id => source.id, :source_ref => SecureRandom.uuid}
+
+    PostLaunchJobTaskService.new(opts).process
+  end
+
   def dispatch
   end
 end

--- a/app/services/check_availability_task_service.rb
+++ b/app/services/check_availability_task_service.rb
@@ -1,0 +1,38 @@
+class CheckAvailabilityTaskService < TaskService
+  attr_reader :task
+
+  def process
+    @task = CheckAvailabilityTask.create!(task_options)
+
+    self
+  end
+
+  private
+
+  def response_format
+    "json"
+  end
+
+  def task_options
+    {}.tap do |options|
+      options[:tenant] = tenant
+      options[:source_id] = source_id
+      options[:state] = 'pending'
+      options[:status] = 'ok'
+      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      options[:input] = task_input
+    end
+  end
+
+  def jobs
+    jobs = []
+
+    check_availability_job = CatalogInventory::Job.new
+    check_availability_job.href_slug = "api/v2/config/"
+    check_availability_job.method = "get"
+    check_availability_job.apply_filter = {"version":"version", "ansible_version":"ansible_version"}
+    jobs << check_availability_job
+
+    jobs
+  end
+end

--- a/app/services/full_refresh_upload_task_service.rb
+++ b/app/services/full_refresh_upload_task_service.rb
@@ -1,0 +1,98 @@
+class FullRefreshUploadTaskService < TaskService
+  attr_reader :task
+
+  def process
+    @task = FullRefreshUploadTask.create!(task_options)
+
+    self
+  end
+
+  private
+
+  def response_format
+    "tar"
+  end
+
+  def task_options
+    {}.tap do |options|
+      options[:tenant] = tenant
+      options[:source_id] = source_id
+      options[:state] = 'pending'
+      options[:status] = 'ok'
+      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      options[:input] = task_input
+    end
+  end
+
+  def jobs
+    jobs = []
+    jobs << templates_job
+    jobs << credentials_job
+    jobs << credential_types_job
+    jobs << inventories_job
+    jobs << workflow_templates_job
+    jobs << workflow_template_nodes_job
+
+    jobs
+  end
+
+  def templates_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/job_templates/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, inventory:inventory, type:type, url:url,created:created,name:name, modified:modified, description:description,survey_spec:related.survey_spec,inventory:related.inventory,survey_enabled:survey_enabled,ask_tags_on_launch:ask_tags_on_launch,ask_limit_on_launch:ask_limit_on_launch,ask_job_type_on_launch:ask_job_type_on_launch,ask_diff_mode_on_launch:ask_diff_mode_on_launch,ask_inventory_on_launch:ask_inventory_on_launch,ask_skip_tags_on_launch:ask_skip_tags_on_launch,ask_variables_on_launch:ask_variables_on_launch,ask_verbosity_on_launch:ask_verbosity_on_launch,ask_credential_on_launch:ask_credential_on_launch}"
+      job.fetch_related = fetch_related
+    end
+  end
+
+  def credentials_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/credentials/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, credential_type:credential_type}"
+    end
+  end
+
+  def credential_types_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/credential_types/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, kind:kind, namespace:namespace}"
+    end
+  end
+
+  def inventories_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/inventories/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, kind:kind, type:type, variables:variables, host_filter:host_filter, pending_deletion:pending_deletion, organization:organization, inventory_sources_with_failures:inventory_sources_with_failures}"
+    end
+  end
+
+  def workflow_templates_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/workflow_job_templates/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, inventory:inventory, type:type, url:url,created:created, name:name, modified:modified, description:description, survey_spec:related.survey_spec, inventory:related.inventory, survey_enabled:survey_enabled, ask_inventory_on_launch:ask_inventory_on_launch, ask_variables_on_launch:ask_variables_on_launch}"
+      job.fetch_related = fetch_related
+    end
+  end
+
+  def workflow_template_nodes_job
+    CatalogInventory::Job.new.tap do |job|
+      job.href_slug = "#{TOWER_API_VERSION}/workflow_job_template_nodes/"
+      job.method = "GET"
+      job.fetch_all_pages = true
+      job.apply_filter = "results[].{id:id, unified_job_type:summary_fields.unified_job_template.unified_job_type, inventory:inventory, type:type, url:url, created:created, modified:modified, workflow_job_template:workflow_job_template, unified_job_template:unified_job_template}"
+    end
+  end
+
+  def upload_url
+    ENV.fetch("UPLOAD_URL") || raise("UPLOAD_URL must be specified")
+  end
+end

--- a/app/services/incremental_refresh_upload_task_service.rb
+++ b/app/services/incremental_refresh_upload_task_service.rb
@@ -1,0 +1,162 @@
+class IncrementalRefreshUploadTaskService < TaskService
+  attr_reader :task
+
+  def initialize(params)
+    super
+    @last_successful_refresh_at = params.require(:last_successful_refresh_at)
+  end
+
+  def process
+    @task = IncrementalRefreshUploadTask.create!(task_options)
+
+    self
+  end
+
+  def response_format
+    "tar"
+  end
+
+  def task_options
+    {}.tap do |options|
+      options[:tenant] = tenant
+      options[:source_id] = source_id
+      options[:state] = 'pending'
+      options[:status] = 'ok'
+      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      options[:input] = task_input
+    end
+  end
+
+  def jobs
+    jobs = []
+    jobs << templates_jobs
+    jobs << credentials_jobs
+    jobs << credential_types_jobs
+    jobs << inventories_jobs
+    jobs << workflow_templates_jobs
+    jobs << workflow_template_nodes_jobs
+
+    jobs.flatten
+  end
+
+  def templates_jobs
+    [].tap do |templates_jobs|
+      templates_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/job_templates?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, inventory:inventory, type:type, url:url,created:created,name:name, modified:modified, description:description,survey_spec:related.survey_spec,inventory:related.inventory,survey_enabled:survey_enabled,ask_tags_on_launch:ask_tags_on_launch,ask_limit_on_launch:ask_limit_on_launch,ask_job_type_on_launch:ask_job_type_on_launch,ask_diff_mode_on_launch:ask_diff_mode_on_launch,ask_inventory_on_launch:ask_inventory_on_launch,ask_skip_tags_on_launch:ask_skip_tags_on_launch,ask_variables_on_launch:ask_variables_on_launch,ask_verbosity_on_launch:ask_verbosity_on_launch,ask_credential_on_launch:ask_credential_on_launch}"
+        job.fetch_related = fetch_related
+      end
+
+      templates_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/job_templates/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.fetch_related = fetch_related
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def credentials_jobs
+    [].tap do |credentials_jobs|
+      credentials_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/credentials?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, credential_type:credential_type}"
+      end
+
+      credentials_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/credentials/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def credential_types_jobs
+    [].tap do |credential_types_jobs|
+      credential_types_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/credential_types?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, kind:kind, namespace:namespace}"
+      end
+
+      credential_types_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/credential_types/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def inventories_jobs
+    [].tap do |inventories_jobs|
+      inventories_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/inventories?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, type:type, created:created, name:name, modified:modified, description:description, kind:kind, type:type, variables:variables, host_filter:host_filter, pending_deletion:pending_deletion, organization:organization, inventory_sources_with_failures:inventory_sources_with_failures}"
+      end
+
+      inventories_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/inventories/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def workflow_templates_jobs
+    [].tap do |workflow_templates_jobs|
+      workflow_templates_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/workflow_job_templates?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, inventory:inventory, type:type, url:url,created:created, name:name, modified:modified, description:description, survey_spec:related.survey_spec, inventory:related.inventory, survey_enabled:survey_enabled, ask_inventory_on_launch:ask_inventory_on_launch, ask_variables_on_launch:ask_variables_on_launch}"
+        job.fetch_related = fetch_related
+      end
+
+      workflow_templates_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/workflow_job_templates/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def workflow_template_nodes_jobs
+    [].tap do |workflow_template_nodes_jobs|
+      workflow_template_nodes_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/workflow_job_template_nodes?modified__gt=#{@last_successful_refresh_at}"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id, unified_job_type:summary_fields.unified_job_template.unified_job_type, inventory:inventory, type:type, url:url, created:created, modified:modified, workflow_job_template:workflow_job_template, unified_job_template:unified_job_template}"
+      end
+
+      workflow_template_nodes_jobs << CatalogInventory::Job.new.tap do |job|
+        job.href_slug = "#{TOWER_API_VERSION}/workflow_job_template_nodes/"
+        job.method = "GET"
+        job.fetch_all_pages = true
+        job.apply_filter = "results[].{id:id}"
+        job.page_prefix = "id"
+      end
+    end
+  end
+
+  def upload_url
+    ENV.fetch("UPLOAD_URL") || raise("UPLOAD_URL must be specified")
+  end
+end

--- a/app/services/incremental_refresh_upload_task_service.rb
+++ b/app/services/incremental_refresh_upload_task_service.rb
@@ -1,9 +1,9 @@
 class IncrementalRefreshUploadTaskService < TaskService
   attr_reader :task
 
-  def initialize(params)
+  def initialize(options)
     super
-    @last_successful_refresh_at = params.require(:last_successful_refresh_at)
+    @last_successful_refresh_at = options[:last_successful_refresh_at]
   end
 
   def process
@@ -17,13 +17,13 @@ class IncrementalRefreshUploadTaskService < TaskService
   end
 
   def task_options
-    {}.tap do |options|
-      options[:tenant] = tenant
-      options[:source_id] = source_id
-      options[:state] = 'pending'
-      options[:status] = 'ok'
-      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
-      options[:input] = task_input
+    {}.tap do |opts|
+      opts[:tenant] = tenant
+      opts[:source_id] = source_id
+      opts[:state] = 'pending'
+      opts[:status] = 'ok'
+      opts[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      opts[:input] = task_input
     end
   end
 

--- a/app/services/launch_job_task_service.rb
+++ b/app/services/launch_job_task_service.rb
@@ -1,9 +1,9 @@
 class LaunchJobTaskService < TaskService
   attr_reader :task
 
-  def initialize(params)
+  def initialize(options)
     super
-    @service_offering = ServiceOffering.find(params.require(:service_offering_id))
+    @service_offering = ServiceOffering.find(@options[:service_offering_id])
   end
 
   def process
@@ -15,13 +15,13 @@ class LaunchJobTaskService < TaskService
   private
 
   def task_options
-    {}.tap do |options|
-      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
-      options[:source_id] = source_id
-      options[:tenant] = tenant
-      options[:state]  = 'pending'
-      options[:status] = 'ok'
-      options[:input] = task_input
+    {}.tap do |opts|
+      opts[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      opts[:source_id] = source_id
+      opts[:tenant] = tenant
+      opts[:state]  = 'pending'
+      opts[:status] = 'ok'
+      opts[:input] = task_input
     end
   end
 
@@ -51,6 +51,6 @@ class LaunchJobTaskService < TaskService
   end
 
   def payload_params
-    {:extra_vars => @params[:service_parameters] || {}}
+    {:extra_vars => @options[:service_parameters] || {}}
   end
 end

--- a/app/services/launch_job_task_service.rb
+++ b/app/services/launch_job_task_service.rb
@@ -1,0 +1,56 @@
+class LaunchJobTaskService < TaskService
+  attr_reader :task
+
+  def initialize(params)
+    super
+    @service_offering = ServiceOffering.find(params.require(:service_offering_id))
+  end
+
+  def process
+    @task = LaunchJobTask.create!(task_options)
+
+    self
+  end
+
+  private
+
+  def task_options
+    {}.tap do |options|
+      options[:forwardable_headers] = Insights::API::Common::Request.current_forwardable
+      options[:source_id] = source_id
+      options[:tenant] = tenant
+      options[:state]  = 'pending'
+      options[:status] = 'ok'
+      options[:input] = task_input
+    end
+  end
+
+  def response_format
+    "json"
+  end
+
+  def source_id
+    @service_offering.source_id
+  end
+
+  def tenant
+    @service_offering.tenant
+  end
+
+  def jobs
+    jobs = []
+
+    launch = CatalogInventory::Job.new
+    launch.href_slug = "#{TOWER_API_VERSION}/job_templates/#{@service_offering.source_ref}/launch/"
+    launch.method = "launch"
+    launch.params = payload_params
+    launch.apply_filter = {"id":"id", "status":"status", "started":"started", "url":"url", "type":"type","finished":"finished", "modified":"modified", "description":"description", "extra_vars":"extra_vars", "artifacts":"artifacts", "name":"name","created":"created", "unified_job_template":"unified_job_template"}
+    jobs << launch
+
+    jobs
+  end
+
+  def payload_params
+    {:extra_vars => @params[:service_parameters] || {}}
+  end
+end

--- a/app/services/mqtt_controller_service.rb
+++ b/app/services/mqtt_controller_service.rb
@@ -1,0 +1,26 @@
+class MQTTControllerService < TaskService
+  def initialize(options)
+    super
+
+    @task_id  = options[:task_id] || raise("Missing task_id")
+    @task_url = options[:task_url] || raise("Missing task_url")
+    @mqtt_client_guid = options[:mqtt_client_guid] || raise("Missing mqtt_client_guid")
+    @mqtt_client_url  = options[:mqtt_client_url] || raise("Missing mqtt_client_url")
+  end
+
+  def process
+    system(publish)
+  end
+
+  def publish
+    "mosquitto_pub -L #{@mqtt_client_url}/out/#{@mqtt_client_guid} -m '" + "#{payload}'"
+  end
+
+  def payload
+    {}.tap do |obj|
+      obj["url"] = "#{@task_url}/#{@task_id}"
+      obj["kind"] = "catalog"
+      obj["sent"] = Time.now.utc
+    end.to_json
+  end
+end

--- a/app/services/post_launch_job_task_service.rb
+++ b/app/services/post_launch_job_task_service.rb
@@ -1,12 +1,39 @@
 class PostLaunchJobTaskService < TaskService
-  attr_reader :task
-
   def process
-    @task = PostLaunchJobTask.create!(task_options)
+    create_service_instance
+    create_kafka_event
+
     self
   end
 
-  def task_options
-    {}
+  private
+
+  def create_service_instance
+    instance = ServiceInstance.create!(service_instance_options)
+    Rails.logger.info("ServiceInstance##{instance.id} is created.")
+  end
+
+  def create_kafka_event
+    if ENV['NO_KAFKA'].blank?
+      CatalogInventory::Api::Messaging.client.publish_topic(
+        :service => "platform.catalog-inventory.task-output-stream",
+        # TODO: what's event??
+        :event   => "Task.update",
+        :payload => kafka_payload,
+        :headers => Insights::API::Common::Request.current_forwardable
+      )
+
+      Rails.logger.info("event(Task.update) published to kafka.")
+    end
+  end
+
+  # TODO: populate input
+  def service_instance_options
+    @options.symbolize_keys.slice(:source_id, :tenant_id, :source_ref)
+  end
+
+  # TODO: populate payload
+  def kafka_payload
+    {:params => {}}
   end
 end

--- a/app/services/post_launch_job_task_service.rb
+++ b/app/services/post_launch_job_task_service.rb
@@ -9,7 +9,7 @@ class PostLaunchJobTaskService < TaskService
   private
 
   def create_service_instance
-    instance = ServiceInstance.create!(service_instance_options)
+    instance = ServiceInstance.create!(@options)
     Rails.logger.info("ServiceInstance##{instance.id} is created.")
   end
 
@@ -25,11 +25,6 @@ class PostLaunchJobTaskService < TaskService
 
       Rails.logger.info("event(Task.update) published to kafka.")
     end
-  end
-
-  # TODO: populate input
-  def service_instance_options
-    @options.symbolize_keys.slice(:source_id, :tenant_id, :source_ref)
   end
 
   # TODO: populate payload

--- a/app/services/post_launch_job_task_service.rb
+++ b/app/services/post_launch_job_task_service.rb
@@ -1,0 +1,12 @@
+class PostLaunchJobTaskService < TaskService
+  attr_reader :task
+
+  def process
+    @task = PostLaunchJobTask.create!(task_options)
+    self
+  end
+
+  def task_options
+    {}
+  end
+end

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -1,8 +1,8 @@
 class TaskService
   TOWER_API_VERSION = "api/v2".freeze
 
-  def initialize(params)
-    @params = params
+  def initialize(options)
+    @options = options.symbolize_keys
   end
 
   private
@@ -16,11 +16,11 @@ class TaskService
   end
 
   def tenant
-    Tenant.find_by(:external_tenant => @params.require(:external_tenant))
+    Tenant.find_by(:external_tenant => @options[:external_tenant])
   end
 
   def source_id
-    @params.require(:source_id)
+    @options[:source_id]
   end
 
   def fetch_related

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -1,0 +1,29 @@
+class TaskService
+  TOWER_API_VERSION = "api/v2".freeze
+
+  def initialize(params)
+    @params = params
+  end
+
+  private
+
+  def task_input
+    CatalogInventory::Payload.new(response_format, upload_url, jobs).as_json
+  end
+
+  def upload_url
+    nil
+  end
+
+  def tenant
+    Tenant.find_by(:external_tenant => @params.require(:external_tenant))
+  end
+
+  def source_id
+    @params.require(:source_id)
+  end
+
+  def fetch_related
+    [{:href_slug => "survey_spec", :predicate => "survey_enabled"}]
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module CatalogInventory
     #
     config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
+    config.autoload_paths << Rails.root.join("app", "services").to_s
     config.autoload_paths << Rails.root.join("lib").to_s
 
     config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym

--- a/lib/catalog_inventory/job.rb
+++ b/lib/catalog_inventory/job.rb
@@ -1,0 +1,5 @@
+module CatalogInventory
+  class Job
+    attr_accessor :href_slug, :method, :params, :fetch_all_pages, :apply_filter, :fetch_related, :page_prefix
+  end
+end

--- a/lib/catalog_inventory/payload.rb
+++ b/lib/catalog_inventory/payload.rb
@@ -1,0 +1,11 @@
+module CatalogInventory
+  class Payload
+    attr_accessor :response_format, :upload_url, :jobs
+
+    def initialize(response_format, upload_url, jobs)
+      @response_format = response_format
+      @jobs = jobs
+      @upload_url = upload_url
+    end
+  end
+end

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -70,6 +70,9 @@
     },
     "/service_credential_types": {
       "get": {
+        "tags": [
+          "ServiceCredentialType"
+        ],
         "summary": "List ServiceCredentialTypes",
         "operationId": "listServiceCredentialTypes",
         "description": "Returns an array of ServiceCredentialType objects",
@@ -103,6 +106,9 @@
     },
     "/service_credential_types/{id}": {
       "get": {
+        "tags": [
+          "ServiceCredentialType"
+        ],
         "summary": "Show an existing ServiceCredentialType",
         "operationId": "showServiceCredentialType",
         "description": "Returns a ServiceCredentialType object",
@@ -137,6 +143,9 @@
     },
     "/service_credentials": {
       "get": {
+        "tags": [
+          "ServiceCredential"
+        ],
         "summary": "List ServiceCredentials",
         "operationId": "listServiceCredentials",
         "description": "Returns an array of ServiceCredential objects",
@@ -170,6 +179,9 @@
     },
     "/service_credentials/{id}": {
       "get": {
+        "tags": [
+          "ServiceCredential"
+        ],
         "summary": "Show an existing ServiceCredential",
         "operationId": "showServiceCredential",
         "description": "Returns a ServiceCredential object",
@@ -204,6 +216,9 @@
     },
     "/service_instance_nodes": {
       "get": {
+        "tags": [
+          "ServiceInstanceNode"
+        ],
         "summary": "List ServiceInstanceNodes",
         "operationId": "listServiceInstanceNodes",
         "description": "Returns an array of ServiceInstanceNode objects",
@@ -237,6 +252,9 @@
     },
     "/service_instance_nodes/{id}": {
       "get": {
+        "tags": [
+          "ServiceInstanceNode"
+        ],
         "summary": "Show an existing ServiceInstanceNode",
         "operationId": "showServiceInstanceNode",
         "description": "Returns a ServiceInstanceNode object",
@@ -271,6 +289,9 @@
     },
     "/service_instance_nodes/{id}/service_credentials": {
       "get": {
+        "tags": [
+          "ServiceInstanceNode"
+        ],
         "summary": "List ServiceCredentials for ServiceInstanceNode",
         "operationId": "listServiceInstanceNodeServiceCredentials",
         "description": "Returns an array of ServiceCredential objects",
@@ -317,6 +338,9 @@
     },
     "/service_instances": {
       "get": {
+        "tags": [
+          "ServiceInstance"
+        ],
         "summary": "List ServiceInstances",
         "operationId": "listServiceInstances",
         "description": "Returns an array of ServiceInstance objects",
@@ -350,6 +374,9 @@
     },
     "/service_instances/{id}": {
       "get": {
+        "tags": [
+          "ServiceInstance"
+        ],
         "summary": "Show an existing ServiceInstance",
         "operationId": "showServiceInstance",
         "description": "Returns a ServiceInstance object",
@@ -384,6 +411,9 @@
     },
     "/service_instances/{id}/service_credentials": {
       "get": {
+        "tags": [
+          "ServiceInstance"
+        ],
         "summary": "List ServiceCredentials for ServiceInstance",
         "operationId": "listServiceInstanceServiceCredentials",
         "description": "Returns an array of ServiceCredential objects",
@@ -430,6 +460,9 @@
     },
     "/service_instances/{id}/service_instance_nodes": {
       "get": {
+        "tags": [
+          "ServiceInstance"
+        ],
         "summary": "List ServiceInstanceNodes for ServiceInstance",
         "operationId": "listServiceInstanceServiceInstanceNodes",
         "description": "Returns an array of ServiceInstanceNode objects",
@@ -476,6 +509,9 @@
     },
     "/service_inventories": {
       "get": {
+        "tags": [
+          "ServiceInventory"
+        ],
         "summary": "List ServiceInventories",
         "operationId": "listServiceInventories",
         "description": "Returns an array of ServiceInventory objects",
@@ -509,6 +545,9 @@
     },
     "/service_inventories/{id}": {
       "get": {
+        "tags": [
+          "ServiceInventory"
+        ],
         "summary": "Show an existing ServiceInventory",
         "operationId": "showServiceInventory",
         "description": "Returns a ServiceInventory object",
@@ -543,6 +582,9 @@
     },
     "/service_inventories/{id}/tag": {
       "post": {
+        "tags": [
+          "ServiceInventory"
+        ],
         "summary": "Tag a ServiceInventory",
         "operationId": "tagServiceInventory",
         "description": "Tags a ServiceInventory object",
@@ -587,6 +629,9 @@
     },
     "/service_inventories/{id}/tags": {
       "get": {
+        "tags": [
+          "ServiceInventory"
+        ],
         "summary": "List Tags for ServiceInventory",
         "operationId": "listServiceInventoryTags",
         "description": "Returns an array of Tag objects",
@@ -633,6 +678,9 @@
     },
     "/service_inventories/{id}/untag": {
       "post": {
+        "tags": [
+          "ServiceInventory"
+        ],
         "summary": "Untag a ServiceInventory",
         "operationId": "untagServiceInventory",
         "description": "Untags a ServiceInventory object",
@@ -664,6 +712,9 @@
     },
     "/service_offering_icons": {
       "get": {
+        "tags": [
+          "ServiceOfferingIcon"
+        ],
         "summary": "List ServiceOfferingIcons",
         "operationId": "listServiceOfferingIcons",
         "description": "Returns an array of ServiceOfferingIcon objects",
@@ -697,6 +748,9 @@
     },
     "/service_offering_icons/{id}": {
       "get": {
+        "tags": [
+          "ServiceOfferingIcon"
+        ],
         "summary": "Show an existing ServiceOfferingIcon",
         "operationId": "showServiceOfferingIcon",
         "description": "Returns a ServiceOfferingIcon object",
@@ -731,6 +785,9 @@
     },
     "/service_offering_icons/{id}/icon_data": {
       "get": {
+        "tags": [
+          "ServiceOfferingIcon"
+        ],
         "summary": "Show an existing ServiceOfferingIcon IconData",
         "operationId": "showServiceOfferingIconIconData",
         "description": "Returns a ServiceOfferingIcon IconData",
@@ -759,6 +816,9 @@
     },
     "/service_offering_nodes": {
       "get": {
+        "tags": [
+          "ServiceOfferingNode"
+        ],
         "summary": "List ServiceOfferingNodes",
         "operationId": "listServiceOfferingNodes",
         "description": "Returns an array of ServiceOfferingNode objects",
@@ -792,6 +852,9 @@
     },
     "/service_offering_nodes/{id}": {
       "get": {
+        "tags": [
+          "ServiceOfferingNode"
+        ],
         "summary": "Show an existing ServiceOfferingNode",
         "operationId": "showServiceOfferingNode",
         "description": "Returns a ServiceOfferingNode object",
@@ -826,6 +889,9 @@
     },
     "/service_offering_nodes/{id}/service_credentials": {
       "get": {
+        "tags": [
+          "ServiceOfferingNode"
+        ],
         "summary": "List ServiceCredentials for ServiceOfferingNode",
         "operationId": "listServiceOfferingNodeServiceCredentials",
         "description": "Returns an array of ServiceCredential objects",
@@ -872,6 +938,9 @@
     },
     "/service_offerings": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List ServiceOfferings",
         "operationId": "listServiceOfferings",
         "description": "Returns an array of ServiceOffering objects",
@@ -905,6 +974,9 @@
     },
     "/service_offerings/{id}": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "Show an existing ServiceOffering",
         "operationId": "showServiceOffering",
         "description": "Returns a ServiceOffering object",
@@ -939,6 +1011,9 @@
     },
     "/service_offerings/{id}/applied_inventories": {
       "post": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "Invokes computing of ServiceInventories for given ServiceOffering",
         "operationId": "appliedInventoriesForServiceOffering",
         "description": "Returns a Task id",
@@ -982,6 +1057,9 @@
     },
     "/service_offerings/{id}/order": {
       "post": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "Order an existing ServiceOffering",
         "operationId": "orderServiceOffering",
         "description": "Returns a Task id",
@@ -1025,6 +1103,9 @@
     },
     "/service_offerings/{id}/service_credentials": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List ServiceCredentials for ServiceOffering",
         "operationId": "listServiceOfferingServiceCredentials",
         "description": "Returns an array of ServiceCredential objects",
@@ -1071,6 +1152,9 @@
     },
     "/service_offerings/{id}/service_instances": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List ServiceInstances for ServiceOffering",
         "operationId": "listServiceOfferingServiceInstances",
         "description": "Returns an array of ServiceInstance objects",
@@ -1117,6 +1201,9 @@
     },
     "/service_offerings/{id}/service_offering_nodes": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List ServiceOfferingNodes for ServiceOffering",
         "operationId": "listServiceOfferingServiceOfferingNodes",
         "description": "Returns an array of ServiceOfferingNode objects",
@@ -1163,6 +1250,9 @@
     },
     "/service_offerings/{id}/service_plans": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List ServicePlans for ServiceOffering",
         "operationId": "listServiceOfferingServicePlans",
         "description": "Returns an array of ServicePlan objects",
@@ -1209,6 +1299,9 @@
     },
     "/service_offerings/{id}/tag": {
       "post": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "Tag a ServiceOffering",
         "operationId": "tagServiceOffering",
         "description": "Tags a ServiceOffering object",
@@ -1253,6 +1346,9 @@
     },
     "/service_offerings/{id}/tags": {
       "get": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "List Tags for ServiceOffering",
         "operationId": "listServiceOfferingTags",
         "description": "Returns an array of Tag objects",
@@ -1299,6 +1395,9 @@
     },
     "/service_offerings/{id}/untag": {
       "post": {
+        "tags": [
+          "ServiceOffering"
+        ],
         "summary": "Untag a ServiceOffering",
         "operationId": "untagServiceOffering",
         "description": "Untags a ServiceOffering object",
@@ -1330,6 +1429,9 @@
     },
     "/service_plans": {
       "get": {
+        "tags": [
+          "ServicePlan"
+        ],
         "summary": "List ServicePlans",
         "operationId": "listServicePlans",
         "description": "Returns an array of ServicePlan objects",
@@ -1363,6 +1465,9 @@
     },
     "/service_plans/{id}": {
       "get": {
+        "tags": [
+          "ServicePlan"
+        ],
         "summary": "Show an existing ServicePlan",
         "operationId": "showServicePlan",
         "description": "Returns a ServicePlan object",
@@ -1397,6 +1502,9 @@
     },
     "/service_plans/{id}/order": {
       "post": {
+        "tags": [
+          "ServicePlan"
+        ],
         "summary": "Order an existing ServicePlan",
         "operationId": "orderServicePlan",
         "description": "Returns a Task id",
@@ -1440,6 +1548,9 @@
     },
     "/service_plans/{id}/service_instances": {
       "get": {
+        "tags": [
+          "ServicePlan"
+        ],
         "summary": "List ServiceInstances for ServicePlan",
         "operationId": "listServicePlanServiceInstances",
         "description": "Returns an array of ServiceInstance objects",
@@ -1486,6 +1597,9 @@
     },
     "/sources": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List Sources",
         "operationId": "listSources",
         "description": "Returns an array of Source objects",
@@ -1519,6 +1633,9 @@
     },
     "/sources/{id}": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "Show an existing Source",
         "operationId": "showSource",
         "description": "Returns a Source object",
@@ -1553,6 +1670,9 @@
     },
     "/sources/{id}/service_instance_nodes": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServiceInstanceNodes for Source",
         "operationId": "listSourceServiceInstanceNodes",
         "description": "Returns an array of ServiceInstanceNode objects",
@@ -1599,6 +1719,9 @@
     },
     "/sources/{id}/service_instances": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServiceInstances for Source",
         "operationId": "listSourceServiceInstances",
         "description": "Returns an array of ServiceInstance objects",
@@ -1645,6 +1768,9 @@
     },
     "/sources/{id}/service_inventories": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServiceInventories for Source",
         "operationId": "listSourceServiceInventories",
         "description": "Returns an array of ServiceInventory objects",
@@ -1691,6 +1817,9 @@
     },
     "/sources/{id}/service_offering_nodes": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServiceOfferingNodes for Source",
         "operationId": "listSourceServiceOfferingNodes",
         "description": "Returns an array of ServiceOfferingNode objects",
@@ -1737,6 +1866,9 @@
     },
     "/sources/{id}/service_offerings": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServiceOfferings for Source",
         "operationId": "listSourceServiceOfferings",
         "description": "Returns an array of ServiceOffering objects",
@@ -1783,6 +1915,9 @@
     },
     "/sources/{id}/service_plans": {
       "get": {
+        "tags": [
+          "Source"
+        ],
         "summary": "List ServicePlans for Source",
         "operationId": "listSourceServicePlans",
         "description": "Returns an array of ServicePlan objects",
@@ -1829,6 +1964,9 @@
     },
     "/tags": {
       "get": {
+        "tags": [
+          "Tags"
+        ],
         "summary": "List Tags",
         "operationId": "listTags",
         "description": "Returns an array of Tag objects",
@@ -1862,6 +2000,9 @@
     },
     "/tags/{id}": {
       "get": {
+        "tags": [
+          "Tags"
+        ],
         "summary": "Show an existing Tag",
         "operationId": "showTag",
         "description": "Returns a Tag object",
@@ -1896,6 +2037,9 @@
     },
     "/tags/{id}/service_inventories": {
       "get": {
+        "tags": [
+          "Tags"
+        ],
         "summary": "List ServiceInventories for Tag",
         "operationId": "listTagServiceInventories",
         "description": "Returns an array of ServiceInventory objects",
@@ -1942,6 +2086,9 @@
     },
     "/tags/{id}/service_offerings": {
       "get": {
+        "tags": [
+          "Tags"
+        ],
         "summary": "List ServiceOfferings for Tag",
         "operationId": "listTagServiceOfferings",
         "description": "Returns an array of ServiceOffering objects",
@@ -1988,6 +2135,9 @@
     },
     "/tasks": {
       "get": {
+        "tags": [
+          "Task"
+        ],
         "summary": "List Tasks",
         "operationId": "listTasks",
         "description": "Returns an array of Task objects",
@@ -2021,6 +2171,9 @@
     },
     "/tasks/{id}": {
       "get": {
+        "tags": [
+          "Task"
+        ],
         "summary": "Show an existing Task",
         "operationId": "showTask",
         "description": "Returns a Task object",
@@ -2053,6 +2206,9 @@
         }
       },
       "patch": {
+        "tags": [
+          "Task"
+        ],
         "summary": "Update an existing Task",
         "operationId": "updateTask",
         "description": "Updates a Task object",
@@ -3283,6 +3439,18 @@
           }
         },
         "additionalProperties": false
+      },
+      "IncrementalRefreshUploadTask": {
+        "$ref": "#/components/schemas/Task"
+      },
+      "FullRefreshUploadTask": {
+        "$ref": "#/components/schemas/Task"
+      },
+      "CheckAvailabilityTask": {
+        "$ref": "#/components/schemas/Task"
+      },
+      "LaunchJobTask": {
+        "$ref": "#/components/schemas/Task"
       },
       "TasksCollection": {
         "type": "object",

--- a/spec/factories/service_inventories.rb
+++ b/spec/factories/service_inventories.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :service_inventory do
+  end
+end

--- a/spec/factories/service_offering_icons.rb
+++ b/spec/factories/service_offering_icons.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :service_offering_icon do
+  end
+end

--- a/spec/factories/service_offerings.rb
+++ b/spec/factories/service_offerings.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :service_offering do
+    source
+  end
+end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :source do
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,38 @@
+describe Task do
+  include ::Spec::Support::TenantIdentity
+
+  let(:task) { Task.create!(:name => "task2", :tenant => tenant, :source => source) }
+  let(:source) { Source.create!(:name => "source1", :tenant => tenant) }
+
+  describe "after_update callback" do
+    context "when LaunchJobTask has completed state" do
+      let(:launch_job_task) { LaunchJobTask.create!(:name => "task", :state => "completed", :status => "ok", :tenant => tenant, :source => source) }
+
+      it "calls post_launch_job_task" do
+        expect(launch_job_task).to receive(:post_launch_job_task)
+
+        launch_job_task.run_callbacks :update
+      end
+    end
+
+    context "when LaunchJobTask's state is not completed" do
+      let(:launch_job_task) { LaunchJobTask.create!(:name => "task", :state => "pending", :status => "ok", :tenant => tenant, :source => source) }
+
+      it "no calls to post_launch_job_task" do
+        expect(launch_job_task).to_not receive(:post_launch_job_task)
+
+        launch_job_task.run_callbacks :update
+      end
+    end
+
+    context "when other task has completed state" do
+      let(:task) { Task.create!(:name => "task", :state => "completed", :status => "ok", :tenant => tenant, :source => source) }
+
+      it "no calls to post_launch_job_task" do
+        expect(task).to_not receive(:post_launch_job_task)
+
+        task.run_callbacks :update
+      end
+    end
+  end
+end

--- a/spec/services/check_availability_task_service_spec.rb
+++ b/spec/services/check_availability_task_service_spec.rb
@@ -1,0 +1,24 @@
+describe CheckAvailabilityTaskService do
+  include ::Spec::Support::TenantIdentity
+
+  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, 'source_id' => source.id) }
+  let(:subject) { described_class.new(params) }
+
+  around do |example|
+    Insights::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  describe "#process" do
+    it "returns CheckAvailabilityTask type of task" do
+      task = subject.process.task
+
+      expect(task.type).to eq('CheckAvailabilityTask')
+      expect(task.input["response_format"]).to eq('json')
+      expect(task.input["jobs"]).to eq([{"apply_filter"=>{"ansible_version"=>"ansible_version", "version"=>"version"}, "href_slug"=>"api/v2/config/", "method"=>"get"}])
+      expect(task.input["upload_url"]).to be_nil
+      expect(task.state).to eq('pending')
+      expect(task.status).to eq('ok')
+    end
+  end
+end

--- a/spec/services/check_availability_task_service_spec.rb
+++ b/spec/services/check_availability_task_service_spec.rb
@@ -2,7 +2,7 @@ describe CheckAvailabilityTaskService do
   include ::Spec::Support::TenantIdentity
 
   let(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, 'source_id' => source.id) }
+  let(:params) { {'external_tenant' => tenant.external_tenant, 'source_id' => source.id} }
   let(:subject) { described_class.new(params) }
 
   around do |example|

--- a/spec/services/full_refresh_upload_task_service_spec.rb
+++ b/spec/services/full_refresh_upload_task_service_spec.rb
@@ -1,0 +1,26 @@
+describe FullRefreshUploadTaskService do
+  include ::Spec::Support::TenantIdentity
+
+  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, :source_id => source.id) }
+  let(:subject) { described_class.new(params) }
+
+  around do |example|
+    with_modified_env(:UPLOAD_URL => "http://www.upload_url.com") do
+      Insights::API::Common::Request.with_request(default_request) { example.call }
+    end
+  end
+
+  describe "#process" do
+    it "returns FullRefreshUploadTask" do
+      task = subject.process.task
+
+      expect(task.type).to eq('FullRefreshUploadTask')
+      expect(task.input["response_format"]).to eq('tar')
+      expect(task.input["jobs"].count).to eq(6)
+      expect(task.input["upload_url"]).to eq('http://www.upload_url.com')
+      expect(task.state).to eq('pending')
+      expect(task.status).to eq('ok')
+    end
+  end
+end

--- a/spec/services/full_refresh_upload_task_service_spec.rb
+++ b/spec/services/full_refresh_upload_task_service_spec.rb
@@ -2,7 +2,7 @@ describe FullRefreshUploadTaskService do
   include ::Spec::Support::TenantIdentity
 
   let(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, :source_id => source.id) }
+  let(:params) { {'external_tenant' => tenant.external_tenant, :source_id => source.id} }
   let(:subject) { described_class.new(params) }
 
   around do |example|

--- a/spec/services/incremental_refresh_upload_task_service_spec.rb
+++ b/spec/services/incremental_refresh_upload_task_service_spec.rb
@@ -1,0 +1,26 @@
+describe IncrementalRefreshUploadTaskService do
+  include ::Spec::Support::TenantIdentity
+
+  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, :source_id => source.id, :last_successful_refresh_at => Time.current.to_s) }
+  let(:subject) { described_class.new(params) }
+
+  around do |example|
+    with_modified_env(:UPLOAD_URL => "http://www.upload_url.com") do
+      Insights::API::Common::Request.with_request(default_request) { example.call }
+    end
+  end
+
+  describe "#process" do
+    it "returns IncrementalRefreshUploadTask" do
+      task = subject.process.task
+
+      expect(task.type).to eq('IncrementalRefreshUploadTask')
+      expect(task.input["response_format"]).to eq('tar')
+      expect(task.input["jobs"].count).to eq(12)
+      expect(task.input["upload_url"]).to eq('http://www.upload_url.com')
+      expect(task.state).to eq('pending')
+      expect(task.status).to eq('ok')
+    end
+  end
+end

--- a/spec/services/incremental_refresh_upload_task_service_spec.rb
+++ b/spec/services/incremental_refresh_upload_task_service_spec.rb
@@ -2,7 +2,7 @@ describe IncrementalRefreshUploadTaskService do
   include ::Spec::Support::TenantIdentity
 
   let(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { ActionController::Parameters.new('external_tenant' => tenant.external_tenant, :source_id => source.id, :last_successful_refresh_at => Time.current.to_s) }
+  let(:params) { {'external_tenant' => tenant.external_tenant, :source_id => source.id, :last_successful_refresh_at => Time.current.to_s} }
   let(:subject) { described_class.new(params) }
 
   around do |example|

--- a/spec/services/launch_job_task_service_spec.rb
+++ b/spec/services/launch_job_task_service_spec.rb
@@ -12,7 +12,7 @@ describe LaunchJobTaskService do
   let(:service_inventory) { FactoryBot.create(:service_inventory, :tenant => tenant, :source_ref => '10') }
   let(:service_offering_icon) { FactoryBot.create(:service_offering_icon, :tenant => tenant, :source => source, :source_ref => '10') }
 
-  let(:params) { ActionController::Parameters.new('service_offering_id' => service_offering.id) }
+  let(:params) { {'service_offering_id' => service_offering.id} }
   let(:subject) { described_class.new(params) }
 
   around do |example|

--- a/spec/services/launch_job_task_service_spec.rb
+++ b/spec/services/launch_job_task_service_spec.rb
@@ -1,0 +1,31 @@
+describe LaunchJobTaskService do
+  include ::Spec::Support::TenantIdentity
+
+  let(:service_offering) do
+    FactoryBot.create(:service_offering, :tenant                => tenant,
+                                         :source_ref            => '10',
+                                         :source_id             => source.id,
+                                         :service_inventory     => service_inventory,
+                                         :service_offering_icon => service_offering_icon)
+  end
+  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:service_inventory) { FactoryBot.create(:service_inventory, :tenant => tenant, :source_ref => '10') }
+  let(:service_offering_icon) { FactoryBot.create(:service_offering_icon, :tenant => tenant, :source => source, :source_ref => '10') }
+
+  let(:params) { ActionController::Parameters.new('service_offering_id' => service_offering.id) }
+  let(:subject) { described_class.new(params) }
+
+  around do |example|
+    Insights::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  describe "#process" do
+    it "returns LaunchJobTask type of task" do
+      task = subject.process.task
+
+      expect(task.type).to eq('LaunchJobTask')
+      expect(task.state).to eq('pending')
+      expect(task.status).to eq('ok')
+    end
+  end
+end

--- a/spec/services/post_launch_job_task_service_spec.rb
+++ b/spec/services/post_launch_job_task_service_spec.rb
@@ -1,0 +1,22 @@
+describe PostLaunchJobTaskService do
+  include ::Spec::Support::TenantIdentity
+
+  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:params) { {'source_id' => source.id, 'tenant_id' => tenant.id, 'source_ref' => SecureRandom.uuid} }
+  let(:subject) { described_class.new(params) }
+
+  around do |example|
+    Insights::API::Common::Request.with_request(default_request) { example.call }
+  end
+
+  describe "#process" do
+    it "should create a ServiceInstance" do
+      expect(CatalogInventory::Api::Messaging.client).to receive(:publish_topic)
+
+      subject.process
+
+      expect(ServiceInstance.count).to eq(1)
+      expect(ServiceInstance.first.source_ref).to eq(params["source_ref"])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,4 +102,6 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.include UserHeaderSpecHelper
+  config.include ServiceSpecHelper
 end

--- a/spec/support/spec_service_helper.rb
+++ b/spec/support/spec_service_helper.rb
@@ -1,0 +1,31 @@
+module ServiceSpecHelper
+  RSpec.configure do |config|
+    config.around(:example, :type => :service) do |example|
+      default_tenant = Tenant.first_or_create!(:external_tenant => default_account_number)
+
+      ActsAsTenant.with_tenant(default_tenant) do
+        example.call
+      end
+
+      Tenant.delete_all
+    end
+  end
+
+  def default_headers
+    { 'x-rh-identity'            => encoded_user_hash,
+      'x-rh-insights-request-id' => 'gobbledygook' }
+  end
+
+  def original_url
+    "http://example.com"
+  end
+
+  def default_request
+    { :headers => default_headers, :original_url => original_url }
+  end
+
+  def with_modified_env(options, &block)
+    Thread.current[:api_instance] = nil
+    ClimateControl.modify(options, &block)
+  end
+end

--- a/spec/support/user_header_spec_helper.rb
+++ b/spec/support/user_header_spec_helper.rb
@@ -1,0 +1,119 @@
+module UserHeaderSpecHelper
+  DEFAULT_USER = {
+    "entitlements" => {
+      "ansible"          => {
+        "is_entitled" => true
+      },
+      "hybrid_cloud"     => {
+        "is_entitled" => true
+      },
+      "insights"         => {
+        "is_entitled" => true
+      },
+      "migrations"       => {
+        "is_entitled" => true
+      },
+      "openshift"        => {
+        "is_entitled" => true
+      },
+      "smart_management" => {
+        "is_entitled" => true
+      }
+    },
+    "identity" => {
+      "account_number" => "0369233",
+      "type"           => "User",
+      "auth_type"      => "basic-auth",
+      "user"           =>  {
+        "username"     => "jdoe",
+        "email"        => "jdoe@acme.com",
+        "first_name"   => "John",
+        "last_name"    => "Doe",
+        "is_active"    => true,
+        "is_org_admin" => false,
+        "is_internal"  => false,
+        "locale"       => "en_US"
+      },
+      "internal"       => {
+        "org_id"    => "3340851",
+        "auth_time" => 6300
+      }
+    }
+  }.freeze
+
+  DEFAULT_SYSTEM = {
+    "entitlements" => {
+      "ansible"          => {
+        "is_entitled" => true
+      },
+      "hybrid_cloud"     => {
+        "is_entitled" => true
+      },
+      "insights"         => {
+        "is_entitled" => true
+      },
+      "migrations"       => {
+        "is_entitled" => true
+      },
+      "openshift"        => {
+        "is_entitled" => true
+      },
+      "smart_management" => {
+        "is_entitled" => true
+      }
+    },
+    "identity" => {
+      "account_number" => "0369233",
+      "type"           => "System",
+      "auth_type"      => "cert-auth",
+      "system"         => {
+        "cn" => "certificate"
+      },
+      "internal"       => {
+        "org_id"    => "3340851",
+        "auth_time" => 6300
+      }
+    }
+  }.freeze
+
+  def default_account_number
+    default_user_hash["identity"]["account_number"]
+  end
+
+  def default_username
+    default_user_hash["identity"]["user"]["username"]
+  end
+
+  def default_auth_type
+    default_user_hash["identity"]["auth_type"]
+  end
+
+  def default_system_cn
+    default_system_hash["identity"]["system"]["cn"]
+  end
+
+  def encode(val)
+    if val.kind_of?(Hash)
+      hashed = val.stringify_keys
+      Base64.strict_encode64(hashed.to_json)
+    else
+      raise StandardError, "Must be a Hash"
+    end
+  end
+
+  def encoded_user_hash(hash = nil)
+    encode(hash || DEFAULT_USER)
+  end
+
+  def encoded_system_hash(hash = nil)
+    encode(hash || DEFAULT_SYSTEM)
+  end
+
+  def default_user_hash
+    Marshal.load(Marshal.dump(DEFAULT_USER))
+  end
+
+  def default_system_hash
+    Marshal.load(Marshal.dump(DEFAULT_SYSTEM))
+  end
+end


### PR DESCRIPTION
In this PR:

1. refactor/add 10 task types;
2. add two helper class `job` and `payload` to create task payload;
3. use helpler classes to create input for task type: `LaunchJobTask`, `FullRefreshUploadTask`, `CheckAvailabilityTask` and `IncrementalRefreshUploadTask`;
4. add corresponding service classes for these tasks;
5. add MQTTControllerService to connect to MQTT broker/client;
6. add post service for `LaunchJobTask`;

`service_offerings/order` will launch a job from beginning to the end