### PR TITLE
Add source enabled check

### DIFF
--- a/app/services/application_task_service.rb
+++ b/app/services/application_task_service.rb
@@ -1,0 +1,18 @@
+class ApplicationTaskService
+  def initialize(options)
+    @options = options.deep_symbolize_keys
+    validate_options
+  end
+
+  def process
+    return if ENV["APPLICATION_TYPE_ID"].blank? || ENV["APPLICATION_TYPE_ID"] != @options[:application_type_id]
+
+    Source.update(@options[:source_id], :enabled => @options[:enabled])
+  end
+
+  private
+
+  def validate_options
+    raise("Options must have source_id and application_type_id keys") unless @options[:source_id].present? && @options[:application_type_id].present?
+  end
+end

--- a/app/services/check_availability_task_service.rb
+++ b/app/services/check_availability_task_service.rb
@@ -2,6 +2,11 @@ class CheckAvailabilityTaskService < TaskService
   attr_reader :task
 
   def process
+    unless source_enabled?
+      Rails.logger.debug("Source #{source_id} is disabled")
+      return self
+    end
+
     @task = CheckAvailabilityTask.create!(task_options)
 
     self

--- a/app/services/full_refresh_upload_task_service.rb
+++ b/app/services/full_refresh_upload_task_service.rb
@@ -2,6 +2,11 @@ class FullRefreshUploadTaskService < TaskService
   attr_reader :task
 
   def process
+    unless source_enabled?
+      Rails.logger.debug("Source #{source_id} is disabled")
+      return self
+    end
+
     @task = FullRefreshUploadTask.create!(task_options)
 
     self

--- a/app/services/persister_task_service.rb
+++ b/app/services/persister_task_service.rb
@@ -7,6 +7,8 @@ class PersisterTaskService
   end
 
   def process
+    return self unless source_enabled?
+
     @task = FullRefreshPersisterTask.create!(opts)
     KafkaEventService.raise_event("platform.catalog.persister", "persister", payload)
 
@@ -19,6 +21,10 @@ class PersisterTaskService
     unless @options[:category].present? && @options[:url].present? && @options[:size].present?
       raise("Options must have category, url and size keys")
     end
+  end
+
+  def source_enabled?
+    Source.find_by(:id => @upload_task.source_id)&.enabled
   end
 
   def opts

--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -1,5 +1,7 @@
 class SourceCreateTaskService < TaskService
   def process
+    return if ENV["SOURCE_TYPE_ID"].blank? || ENV["SOURCE_TYPE_ID"] != @options[:source_type_id]
+
     Source.create!(source_options)
   end
 

--- a/app/services/source_destroy_task_service.rb
+++ b/app/services/source_destroy_task_service.rb
@@ -4,6 +4,8 @@ class SourceDestroyTaskService
   end
 
   def process
+    return if ENV["SOURCE_TYPE_ID"].blank? || ENV["SOURCE_TYPE_ID"] != @options[:source_type_id]
+
     validate_options
     Source.destroy(@options[:source_id].to_i)
   end

--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -28,6 +28,10 @@ class TaskService
     @options[:source_id]
   end
 
+  def source_enabled?
+    Source.find_by(:id => source_id)&.enabled
+  end
+
   def fetch_related
     [{:href_slug => "survey_spec", :predicate => "survey_enabled"}]
   end

--- a/config/initializers/init_types_envs.rb
+++ b/config/initializers/init_types_envs.rb
@@ -1,18 +1,21 @@
 module InitTypesEnvs
-  SOURCE_TYPE_NAME = "ansible-tower".freeze
-  APPLICATION_TYPE_NAME = "/insights/platform/catalog".freeze
+  # skip the initializer code if in travis build
+  unless ENV["TRAVIS"]
+    SOURCE_TYPE_NAME = "ansible-tower".freeze
+    APPLICATION_TYPE_NAME = "/insights/platform/catalog".freeze
 
-  source_types = Sources::Service.call do |api_instance|
-    api_instance.list_source_types(:filter => {:name => SOURCE_TYPE_NAME})
+    source_types = Sources::Service.call do |api_instance|
+      api_instance.list_source_types(:filter => {:name => SOURCE_TYPE_NAME})
+    end
+
+    application_types = Sources::Service.call do |api_instance|
+      api_instance.list_application_types(:filter => {:name => APPLICATION_TYPE_NAME})
+    end
+
+    source_type_id = source_types.try(:data).try(:first).try(:id)
+    application_type_id = application_types.try(:data).try(:first).try(:id)
+
+    ENV["SOURCE_TYPE_ID"]      = source_type_id
+    ENV["APPLICATION_TYPE_ID"] = application_type_id
   end
-
-  application_types = Sources::Service.call do |api_instance|
-    api_instance.list_application_types(:filter => {:name => APPLICATION_TYPE_NAME})
-  end
-
-  source_type_id = source_types.try(:data).try(:first).try(:id)
-  application_type_id = application_types.try(:data).try(:first).try(:id)
-
-  ENV["SOURCE_TYPE_ID"]      = source_type_id
-  ENV["APPLICATION_TYPE_ID"] = application_type_id
 end

--- a/config/initializers/init_types_envs.rb
+++ b/config/initializers/init_types_envs.rb
@@ -1,0 +1,18 @@
+module InitTypesEnvs
+  SOURCE_TYPE_NAME = "ansible-tower".freeze
+  APPLICATION_TYPE_NAME = "/insights/platform/catalog".freeze
+
+  source_types = Sources::Service.call do |api_instance|
+    api_instance.list_source_types(:filter => {:name => SOURCE_TYPE_NAME})
+  end
+
+  application_types = Sources::Service.call do |api_instance|
+    api_instance.list_application_types(:filter => {:name => APPLICATION_TYPE_NAME})
+  end
+
+  source_type_id = source_types.try(:data).try(:first).try(:id)
+  application_type_id = application_types.try(:data).try(:first).try(:id)
+
+  ENV["SOURCE_TYPE_ID"]      = source_type_id
+  ENV["APPLICATION_TYPE_ID"] = application_type_id
+end

--- a/config/initializers/load_extensions.rb
+++ b/config/initializers/load_extensions.rb
@@ -1,0 +1,1 @@
+require 'sources/service'

--- a/config/initializers/sources_api.rb
+++ b/config/initializers/sources_api.rb
@@ -1,8 +1,0 @@
-scheme = ENV["SOURCES_SCHEME"] || 'http'
-host = ENV["SOURCES_HOST"] || 'localhost'
-port = ENV["SOURCES_PORT"] || 3000
-
-SourcesApiClient.configure do |config|
-  config.scheme = scheme
-  config.host   = "#{host}:#{port}"
-end

--- a/db/migrate/20210107222354_add_enabled_to_sources.rb
+++ b/db/migrate/20210107222354_add_enabled_to_sources.rb
@@ -1,0 +1,5 @@
+class AddEnabledToSources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :enabled, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_201453) do
+ActiveRecord::Schema.define(version: 2021_01_07_222354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -334,6 +334,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_201453) do
     t.string "availability_status"
     t.datetime "last_checked_at"
     t.datetime "last_available_at"
+    t.boolean "enabled", default: false
     t.index ["tenant_id", "uid"], name: "index_sources_on_tenant_id_and_uid", unique: true
   end
 

--- a/lib/events/event_router.rb
+++ b/lib/events/event_router.rb
@@ -8,6 +8,10 @@ module Events
         SourceCreateTaskService.new(payload).process
       when "Source.destroy"
         SourceDestroyTaskService.new(payload).process
+      when "Application.create"
+        ApplicationTaskService.new(payload.merge(:enabled => true)).process
+      when "Application.destroy"
+        ApplicationTaskService.new(payload.merge(:enabled => false)).process
       when "Source.availability_check"
         task = CheckAvailabilityTaskService.new(payload["params"]).process.task
         task.dispatch

--- a/lib/sources/service.rb
+++ b/lib/sources/service.rb
@@ -1,0 +1,56 @@
+module Sources
+  class Service
+    def self.sources_api
+      Thread.current[:sources_api_instance] ||= raw_api
+    end
+
+    def self.call
+      pass_thru_headers
+      yield sources_api
+    rescue SourcesApiClient::ApiError => e
+      Rails.logger.error("SourcesApiClient::ApiError #{e.message}")
+    end
+
+    private_class_method def self.raw_api
+      SourcesApiClient.configure do |config|
+        config.host = ENV['SOURCES_URL'] || 'localhost'
+        config.scheme = URI.parse(ENV['SOURCES_URL']).try(:scheme) || 'http'
+        if Rails.env.development?
+          config.username = ENV['DEV_USERNAME'] || raise("Empty ENV variable: DEV_USERNAME")
+          config.password = ENV['DEV_PASSWORD'] || raise("Empty ENV variable: DEV_PASSWORD")
+        end
+      end
+      SourcesApiClient::DefaultApi.new
+    end
+
+    private_class_method def self.pass_thru_headers
+      headers = {"x-rh-identity" => Base64.strict_encode64(User::DEFAULT_USER.to_json)}
+      sources_api.api_client.default_headers.merge!(headers)
+    end
+  end
+
+  module User
+    DEFAULT_USER ||= {
+      "identity" => {
+        "account_number" => "DUMMY_USER",
+        "type"           => "User",
+        "user"           => {
+          "username"     => "dummy_user",
+          "email"        => "dummy_user@redhat.com",
+          "first_name"   => "dummy",
+          "last_name"    => "user",
+          "is_active"    => false,
+          "is_org_admin" => true,
+          "is_internal"  => false,
+          "system"       => true,
+          "locale"       => "en_US"
+        },
+        "internal"       => {
+          "org_id"    => "1234567",
+          "auth_type" => "basic-auth",
+          "auth_time" => 6300
+        }
+      }
+    }.freeze
+  end
+end

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -3285,12 +3285,20 @@
           "info": {
             "example": "The version of Tower being used",
             "title": "Info",
+            "readOnly": true,
             "type": "object"
           },
           "mqtt_client_id": {
             "example": "The GUID of MQTT client being used",
             "title": "MqttClientId",
+            "readOnly": true,
             "type": "string"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": false,
+            "readOnly": true
           },
           "refresh_state": {
             "type": "string"

--- a/spec/services/check_availability_task_service_spec.rb
+++ b/spec/services/check_availability_task_service_spec.rb
@@ -1,7 +1,6 @@
 describe CheckAvailabilityTaskService do
   include ::Spec::Support::TenantIdentity
 
-  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
   let(:params) { {'external_tenant' => tenant.external_tenant, 'source_id' => source.id} }
   let(:subject) { described_class.new(params) }
 
@@ -10,15 +9,27 @@ describe CheckAvailabilityTaskService do
   end
 
   describe "#process" do
-    it "returns CheckAvailabilityTask type of task" do
-      task = subject.process.task
+    context "when source is enabled" do
+      let(:source) { FactoryBot.create(:source, :tenant => tenant, :enabled => true) }
 
-      expect(task.type).to eq('CheckAvailabilityTask')
-      expect(task.input["response_format"]).to eq('json')
-      expect(task.input["jobs"]).to eq([{"apply_filter"=>{"ansible_version"=>"ansible_version", "version"=>"version"}, "href_slug"=>"api/v2/config/", "method"=>"get"}])
-      expect(task.input["upload_url"]).to be_nil
-      expect(task.state).to eq('pending')
-      expect(task.status).to eq('ok')
+      it "returns CheckAvailabilityTask type of task" do
+        task = subject.process.task
+
+        expect(task.type).to eq('CheckAvailabilityTask')
+        expect(task.input["response_format"]).to eq('json')
+        expect(task.input["jobs"]).to eq([{"apply_filter"=>{"ansible_version"=>"ansible_version", "version"=>"version"}, "href_slug"=>"api/v2/config/", "method"=>"get"}])
+        expect(task.input["upload_url"]).to be_nil
+        expect(task.state).to eq('pending')
+        expect(task.status).to eq('ok')
+      end
+    end
+
+    context "when source is disabled" do
+      let(:source) { FactoryBot.create(:source, :tenant => tenant, :enabled => false) }
+
+      it "returns nil task" do
+        expect(subject.process.task).to be_nil
+      end
     end
   end
 end

--- a/spec/services/full_refresh_upload_task_service_spec.rb
+++ b/spec/services/full_refresh_upload_task_service_spec.rb
@@ -1,7 +1,7 @@
 describe FullRefreshUploadTaskService do
   include ::Spec::Support::TenantIdentity
 
-  let(:source) { FactoryBot.create(:source, :tenant => tenant) }
+  let(:source) { FactoryBot.create(:source, :tenant => tenant, :enabled => true) }
   let(:params) { {'external_tenant' => tenant.external_tenant, :source_id => source.id} }
   let(:subject) { described_class.new(params) }
 

--- a/spec/services/source_create_task_service_spec.rb
+++ b/spec/services/source_create_task_service_spec.rb
@@ -1,20 +1,35 @@
 describe SourceCreateTaskService do
   include ::Spec::Support::TenantIdentity
 
-  let(:params) { {'source_id' => '200', 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
   let(:subject) { described_class.new(params) }
 
   around do |example|
-    Insights::API::Common::Request.with_request(default_request) { example.call }
+    with_modified_env(:SOURCE_TYPE_ID => "10") do
+      Insights::API::Common::Request.with_request(default_request) { example.call }
+    end
   end
 
   describe "#process" do
-    it "should create a ServiceInstance" do
-      subject.process
+    context "when source_type_id matches the environment" do
+      let(:params) { {'source_id' => '200', 'source_type_id' => "10", 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
 
-      expect(Source.count).to eq(1)
-      expect(Source.first.id.to_s).to eq(params["source_id"])
-      expect(Source.first.uid).to eq(params["source_uid"])
+      it "should create a ServiceInstance" do
+        subject.process
+
+        expect(Source.count).to eq(1)
+        expect(Source.first.id.to_s).to eq(params["source_id"])
+        expect(Source.first.uid).to eq(params["source_uid"])
+        expect(Source.first.enabled).to be_falsey
+      end
+    end
+
+    context "when source_type_id doee not matches the environment" do
+      let(:params) { {'source_id' => '200', 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
+
+      it "should do nothing" do
+        subject.process
+        expect(Source.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/services/source_destroy_task_service_spec.rb
+++ b/spec/services/source_destroy_task_service_spec.rb
@@ -2,11 +2,13 @@ describe SourceDestroyTaskService do
   include ::Spec::Support::TenantIdentity
 
   let!(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { {'source_id' => source.id} }
+  let(:params) { {'source_id' => source.id, 'source_type_id' => "10"} }
   let(:subject) { described_class.new(params) }
 
   around do |example|
-    Insights::API::Common::Request.with_request(default_request) { example.call }
+    with_modified_env(:SOURCE_TYPE_ID => "10") do
+      Insights::API::Common::Request.with_request(default_request) { example.call }
+    end
   end
 
   describe "#process" do


### PR DESCRIPTION
This PR contains changes:
1. when service starts, retrieve `source_type_id` and `application_type_id` from Sources service and store them in environment variables: ENV["SOURCE_TYPE_ID"] and ENV["APPLICATION_TYPE_ID"];
2. Only those `Source.create` or `Source.destroy` KAFKA messages with matching `source_type_id` are processed;
3. Only those `Application.create` or `Application.destroy` Kafka messages with matching `application_type_id` are processed;
4. `enabled` attribute is added to `Source` object, default is `false`. It will change to `true` when receiving `Application.create` message, and change to `false` when  `Application.destroy` is received.
5. The check_availability_task, upload_task and persister_task only triggers when its source is enabled.

https://issues.redhat.com/browse/SSP-1991