### PR TITLE
Commit the records into the DB

### DIFF
--- a/app/services/check_availability_task_service.rb
+++ b/app/services/check_availability_task_service.rb
@@ -8,7 +8,7 @@ class CheckAvailabilityTaskService < TaskService
     end
 
     @task = CheckAvailabilityTask.create!(task_options)
-
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   rescue => e
     Rails.logger.error("Failed to create task: #{e.message}")

--- a/app/services/full_refresh_upload_task_service.rb
+++ b/app/services/full_refresh_upload_task_service.rb
@@ -8,7 +8,7 @@ class FullRefreshUploadTaskService < TaskService
     end
 
     @task = FullRefreshUploadTask.create!(task_options)
-
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   end
 

--- a/app/services/launch_job_task_service.rb
+++ b/app/services/launch_job_task_service.rb
@@ -8,7 +8,7 @@ class LaunchJobTaskService < TaskService
 
   def process
     @task = LaunchJobTask.create!(task_options)
-
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   end
 

--- a/app/services/persister_task_service.rb
+++ b/app/services/persister_task_service.rb
@@ -10,6 +10,7 @@ class PersisterTaskService
     return self unless source_enabled?
 
     @task = FullRefreshPersisterTask.create!(opts)
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     KafkaEventService.raise_event("platform.catalog.persister", "persister", payload)
 
     self

--- a/app/services/post_launch_job_task_service.rb
+++ b/app/services/post_launch_job_task_service.rb
@@ -1,6 +1,7 @@
 class PostLaunchJobTaskService < TaskService
   def process
     create_service_instance
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     KafkaEventService.raise_event("platform.catalog-inventory.task-output-stream", "Task.update", kafka_payload)
 
     self

--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -3,6 +3,7 @@ class SourceCreateTaskService < TaskService
     return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
 
     Source.create!(source_options)
+    ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
   end
 
   private


### PR DESCRIPTION
When running in a multi threaded process the transactions needs to
be committed so that other threads can see it, otherwise the other
threads or pocesses wont have visibility to these newly created
objects