### PR TITLE
Source_id should be id when adding/destroying a source

### DIFF
--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -11,8 +11,12 @@ class SourceCreateTaskService < TaskService
   def source_options
     {}.tap do |options|
       options[:tenant_id] = tenant.id
-      options[:id] = @options[:source_id]
+      options[:id] = @options[:id]
       options[:uid] = @options[:source_uid]
     end
+  end
+
+  def validate_options
+    raise("Options must have id") unless @options[:id].present?
   end
 end

--- a/app/services/source_destroy_task_service.rb
+++ b/app/services/source_destroy_task_service.rb
@@ -7,12 +7,12 @@ class SourceDestroyTaskService
     return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
 
     validate_options
-    Source.destroy(@options[:source_id].to_i)
+    Source.destroy(@options[:id].to_i)
   end
 
   private
 
   def validate_options
-    raise("Options must have source_id key") if @options[:source_id].blank?
+    raise("Options must have id key") if @options[:id].blank?
   end
 end

--- a/spec/services/source_create_task_service_spec.rb
+++ b/spec/services/source_create_task_service_spec.rb
@@ -9,20 +9,20 @@ describe SourceCreateTaskService do
 
   describe "#process" do
     context "when source_type_id matches the environment" do
-      let(:params) { {'source_id' => '200', 'source_type_id' => "10", 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
+      let(:params) { {'id' => '200', 'source_type_id' => "10", 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
 
       it "should create a Source" do
         subject.process
 
         expect(Source.count).to eq(1)
-        expect(Source.first.id.to_s).to eq(params["source_id"])
+        expect(Source.first.id.to_s).to eq(params["id"])
         expect(Source.first.uid).to eq(params["source_uid"])
         expect(Source.first.enabled).to be_falsey
       end
     end
 
     context "when source_type_id doee not matches the environment" do
-      let(:params) { {'source_id' => '200', 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
+      let(:params) { {'id' => '200', 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
 
       it "should do nothing" do
         subject.process

--- a/spec/services/source_destroy_task_service_spec.rb
+++ b/spec/services/source_destroy_task_service_spec.rb
@@ -2,7 +2,7 @@ describe SourceDestroyTaskService do
   include ::Spec::Support::TenantIdentity
 
   let!(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { {'source_id' => source.id, 'source_type_id' => "10"} }
+  let(:params) { {'id' => source.id, 'source_type_id' => "10"} }
   let(:subject) { described_class.new(params) }
 
   before do


### PR DESCRIPTION
The Kafka Message when a Source is added has id e.g.

```
{"@timestamp":"2021-01-22T22:42:32.921945 ","hostname":"catalog-inventory-api-9-8flnq","pid":86,"tid":"2b01edd55498","level":"info","message":"Kafka message Source.create received with payload: {\"id\"=\u003e19780, \"name\"=\u003e\"Slate Rock and Gravel Company\", \"uid\"=\u003e\"5699ca7a-58b6-4bf8-8a54-54e2b7318199\", \"created_at\"=\u003e\"2021-01-22 22:42:32 UTC\", \"updated_at\"=\u003e\"2021-01-22 22:42:32 UTC\", \"source_type_id\"=\u003e3, \"version\"=\u003enil, \"availability_status\"=\u003enil, \"imported\"=\u003enil, \"source_ref\"=\u003e\"Yabba_Dabba_Doo\", \"last_checked_at\"=\u003enil, \"last_available_at\"=\u003enil, \"tenant\"=\u003e\"6089719\"}"}
```