### PR TITLE
Source Type ID coming back is a string and not int

### DIFF
--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -2,7 +2,7 @@ class SourceCreateTaskService < TaskService
   def process
     Rails.logger.info("SOURCE TYPE ID #{ClowderConfig.instance["SOURCE_TYPE_ID"]}")
     Rails.logger.info("OPTIONS SOURCE TYPE ID #{@options[:source_type_id]}")
-    return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
+    return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id].to_s
 
     Rails.logger.info("Creating Source")
     Source.create!(source_options)

--- a/spec/services/source_create_task_service_spec.rb
+++ b/spec/services/source_create_task_service_spec.rb
@@ -9,7 +9,7 @@ describe SourceCreateTaskService do
 
   describe "#process" do
     context "when source_type_id matches the environment" do
-      let(:params) { {'id' => '200', 'source_type_id' => "10", 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
+      let(:params) { {'id' => '200', 'source_type_id' => 10, 'external_tenant' => tenant.external_tenant, 'source_uid' => SecureRandom.uuid} }
 
       it "should create a Source" do
         subject.process


### PR DESCRIPTION
When we get the Source Object from Kafka it preserves the source_type_id
as integer, while the same source_type objects id attribute is converted
to string before being sent out via the Rest API.