### PR TITLE
Fixed types added name to source

### DIFF
--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -13,11 +13,14 @@ class SourceCreateTaskService < TaskService
   def source_options
     {}.tap do |options|
       options[:id] = @options[:id]
-      options[:uid] = @options[:source_uid]
+      options[:uid] = @options[:uid]
+      options[:name] = @options[:name]
     end
   end
 
   def validate_options
     raise("Options must have id") unless @options[:id].present?
+    raise("Options must have uid") unless @options[:uid].present?
+    raise("Options must have name") unless @options[:name].present?
   end
 end

--- a/spec/services/source_create_task_service_spec.rb
+++ b/spec/services/source_create_task_service_spec.rb
@@ -14,20 +14,20 @@ describe SourceCreateTaskService do
 
   describe "#process" do
     context "when source_type_id matches the environment" do
-      let(:params) { {'id' => '200', 'source_type_id' => 10, 'source_uid' => SecureRandom.uuid} }
+      let(:params) { {'id' => 200, 'source_type_id' => 10, 'uid' => SecureRandom.uuid, 'name' => 'xyz'} }
 
       it "should create a Source" do
         subject.process
 
         expect(Source.count).to eq(1)
-        expect(Source.first.id.to_s).to eq(params["id"])
-        expect(Source.first.uid).to eq(params["source_uid"])
+        expect(Source.first.id).to eq(params["id"])
+        expect(Source.first.uid).to eq(params["uid"])
         expect(Source.first.enabled).to be_falsey
       end
     end
 
     context "when source_type_id doee not matches the environment" do
-      let(:params) { {'id' => '200', 'source_uid' => SecureRandom.uuid} }
+      let(:params) { {'id' => 200, 'uid' => SecureRandom.uuid, 'name' => 'xyz'} }
 
       it "should do nothing" do
         subject.process


### PR DESCRIPTION
The types needed to be int instead of string when handling Kafka payload
source_uid should have been uid