### PR TITLE
Check Availability Message has no headers

### DIFF
--- a/app/services/check_availability_task_service.rb
+++ b/app/services/check_availability_task_service.rb
@@ -2,16 +2,14 @@ class CheckAvailabilityTaskService < TaskService
   attr_reader :task
 
   def process
-    unless source_enabled?
-      Rails.logger.debug("Source #{source_id} is disabled")
-      return self
-    end
+    raise "Source #{source_id} is disabled" unless source_enabled?
 
     @task = CheckAvailabilityTask.create!(task_options)
     ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   rescue => e
     Rails.logger.error("Failed to create task: #{e.message}")
+    raise
   end
 
   private

--- a/lib/events/kafka_listener.rb
+++ b/lib/events/kafka_listener.rb
@@ -36,13 +36,20 @@ module Events
 
       # Kafka message from Ingress has no headers. We need to prepare the headers from its payload.
       if insights_headers.empty?
-        header_hash = JSON.parse(event.payload)
-        insights_headers['x-rh-insights-request-id'] = header_hash["request_id"]
-        insights_headers['x-rh-identity'] = header_hash["b64_identity"]
+        if event.payload.class == Hash && event.payload.has_key?("params") 
+          # check availability from source doesn't have headers
+          insights_headers['x-rh-insights-request-id'] = "unknown"
+          insights_headers['x-rh-identity'] = identity_from_external_tenant(event.payload["params"]["external_tenant"])
+        else 
+          # ingress doesn't have any header
+          header_hash = json.parse(event.payload)
+          insights_headers['x-rh-insights-request-id'] = header_hash["request_id"]
+          insights_headers['x-rh-identity'] = header_hash["b64_identity"]
+        end
       end
 
       unless insights_headers['x-rh-identity'] && insights_headers['x-rh-insights-request-id']
-        Rails.logger.error("Message skipped because of missing required headers")
+        rails.logger.error("message skipped because of missing required headers")
         return
       end
 
@@ -66,6 +73,51 @@ module Events
 
     def default_messaging_options
       {:protocol => :Kafka, :encoding => 'json'}
+    end
+
+    def identity_from_external_tenant(account_number)
+      hash = {
+        "entitlements" => {
+          "ansible"          => {
+            "is_entitled" => true
+          },
+          "hybrid_cloud"     => {
+            "is_entitled" => true
+          },
+          "insights"         => {
+            "is_entitled" => true
+          },
+          "migrations"       => {
+            "is_entitled" => true
+          },
+          "openshift"        => {
+            "is_entitled" => true
+          },
+          "smart_management" => {
+            "is_entitled" => true
+          }
+        },
+        "identity" => {
+          "account_number" => account_number,
+          "type"           => "User",
+          "auth_type"      => "basic-auth",
+          "user"           =>  {
+            "username"     => "jdoe",
+            "email"        => "jdoe@acme.com",
+            "first_name"   => "John",
+            "last_name"    => "Doe",
+            "is_active"    => true,
+            "is_org_admin" => false,
+            "is_internal"  => false,
+            "locale"       => "en_US"
+          },
+          "internal"       => {
+            "org_id"    => "3340851",
+            "auth_time" => 6300
+          }
+        }
+      }
+      Base64.strict_encode64(hash.to_json)
     end
   end
 end

--- a/spec/services/check_availability_task_service_spec.rb
+++ b/spec/services/check_availability_task_service_spec.rb
@@ -28,7 +28,7 @@ describe CheckAvailabilityTaskService do
       let(:source) { FactoryBot.create(:source, :tenant => tenant, :enabled => false) }
 
       it "returns nil task" do
-        expect(subject.process.task).to be_nil
+        expect{ subject.process.task }.to raise_error(StandardError, /is disabled/)
       end
     end
   end


### PR DESCRIPTION
The Check Availability message doesn't have any headers so we have to fabricate one from external_tenant