### PR TITLE
Leave ID's as integer

### DIFF
--- a/app/services/source_create_task_service.rb
+++ b/app/services/source_create_task_service.rb
@@ -1,6 +1,6 @@
 class SourceCreateTaskService < TaskService
   def process
-    return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id].to_s
+    return if ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
 
     Rails.logger.info("Creating Source")
     Source.create!(source_options)

--- a/app/services/source_destroy_task_service.rb
+++ b/app/services/source_destroy_task_service.rb
@@ -4,15 +4,15 @@ class SourceDestroyTaskService
   end
 
   def process
-    return if ClowderConfig.instance["SOURCE_TYPE_ID"].blank? || ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
+    return if ClowderConfig.instance["SOURCE_TYPE_ID"] != @options[:source_type_id]
 
     validate_options
-    Source.destroy(@options[:id].to_i)
+    Source.destroy(@options[:id])
   end
 
   private
 
   def validate_options
-    raise("Options must have id key") if @options[:id].blank?
+    raise("Options must have id key") unless @options.key?(:id)
   end
 end

--- a/config/initializers/init_types_envs.rb
+++ b/config/initializers/init_types_envs.rb
@@ -12,8 +12,8 @@ module InitTypesEnvs
       api_instance.list_application_types(:filter => {:name => APPLICATION_TYPE_NAME})
     end
 
-    source_type_id = source_types.try(:data).try(:first).try(:id)
-    application_type_id = application_types.try(:data).try(:first).try(:id)
+    source_type_id = source_types.try(:data).try(:first).try(:id).to_i
+    application_type_id = application_types.try(:data).try(:first).try(:id).to_i
     Rails.logger.info("Source Type ID #{source_type_id} Application_type_id #{application_type_id}")
     ClowderConfig.instance.merge!("SOURCE_TYPE_ID" => source_type_id, "APPLICATION_TYPE_ID" => application_type_id)
   end

--- a/spec/services/source_create_task_service_spec.rb
+++ b/spec/services/source_create_task_service_spec.rb
@@ -2,7 +2,7 @@ describe SourceCreateTaskService do
   let(:subject) { described_class.new(params) }
 
   before do
-    allow(ClowderConfig).to receive(:instance).and_return({"SOURCE_TYPE_ID" => "10"})
+    allow(ClowderConfig).to receive(:instance).and_return({"SOURCE_TYPE_ID" => 10})
   end
 
   around do |example|
@@ -26,7 +26,7 @@ describe SourceCreateTaskService do
       end
     end
 
-    context "when source_type_id doee not matches the environment" do
+    context "when source_type_id does not match the environment" do
       let(:params) { {'id' => 200, 'uid' => SecureRandom.uuid, 'name' => 'xyz'} }
 
       it "should do nothing" do

--- a/spec/services/source_destroy_task_service_spec.rb
+++ b/spec/services/source_destroy_task_service_spec.rb
@@ -2,11 +2,11 @@ describe SourceDestroyTaskService do
   include ::Spec::Support::TenantIdentity
 
   let!(:source) { FactoryBot.create(:source, :tenant => tenant) }
-  let(:params) { {'id' => source.id, 'source_type_id' => "10"} }
+  let(:params) { {'id' => source.id, 'source_type_id' => 10} }
   let(:subject) { described_class.new(params) }
 
   before do
-    allow(ClowderConfig).to receive(:instance).and_return({"SOURCE_TYPE_ID" => "10"})
+    allow(ClowderConfig).to receive(:instance).and_return({"SOURCE_TYPE_ID" => 10})
   end
 
   describe "#process" do


### PR DESCRIPTION
The ID's that we get from REST API is string but the ones that
we get from Kafka message are integer's. Since most of the back end
processing we do is based on Kafka messages leave the ID's as integers