### PR TITLE
The Application ID is a integer field dont convert to string

### DIFF
--- a/app/services/application_task_service.rb
+++ b/app/services/application_task_service.rb
@@ -5,7 +5,7 @@ class ApplicationTaskService
   end
 
   def process
-    return if ClowderConfig.instance["APPLICATION_TYPE_ID"].blank? || ClowderConfig.instance["APPLICATION_TYPE_ID"] != @options[:application_type_id].to_s
+    return if ClowderConfig.instance["APPLICATION_TYPE_ID"] != @options[:application_type_id]
 
     Source.update(@options[:source_id], :enabled => @options[:enabled])
   end


### PR DESCRIPTION
It doesn't make sense to be converting the id to string every time before comparison. We convert the id that we fetch via the REST API from a string to int and when we do the comparison here we do int comparison