### PR TITLE
Refresh the source if it is not ready for availability check

### DIFF
--- a/app/services/task_service.rb
+++ b/app/services/task_service.rb
@@ -9,7 +9,7 @@ class TaskService
   private
 
   def validate_options
-    raise("Options must have source_id") unless @options[:source_id].present?
+    raise("Options must have source_id") if @options[:source_id].blank?
   end
 
   def task_input
@@ -30,6 +30,10 @@ class TaskService
 
   def source_enabled?
     Source.find_by(:id => source_id)&.enabled
+  end
+
+  def source_refresh?
+    Source.find_by(:id => source_id)&.mqtt_client_id.nil? || !source_enabled?
   end
 
   def fetch_related

--- a/lib/sources/service.rb
+++ b/lib/sources/service.rb
@@ -24,7 +24,12 @@ module Sources
     end
 
     private_class_method def self.pass_thru_headers
-      headers = {"x-rh-identity" => Headers::Service.x_rh_identity_dummy_admin}
+      headers = if Insights::API::Common::Request.current
+                  Insights::API::Common::Request.current_forwardable
+                else
+                  {"x-rh-identity" => Headers::Service.x_rh_identity_dummy_admin}
+                end
+
       sources_api.api_client.default_headers.merge!(headers)
     end
   end


### PR DESCRIPTION
In the case of multiple pods runs in the same time, the events of `source.create`, `endpoint.create`, `application.create`, and `check_availability` may be consumed by different pods. So before check_availability starts, check with source API to see its latest status 