### PR TITLE
Update source refresh start and finish accordingly

### DIFF
--- a/app/services/full_refresh_upload_task_service.rb
+++ b/app/services/full_refresh_upload_task_service.rb
@@ -8,6 +8,7 @@ class FullRefreshUploadTaskService < TaskService
     end
 
     @task = FullRefreshUploadTask.create!(task_options)
+    Source.update(source_id, :refresh_started_at => Time.current)
     ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   end

--- a/app/services/incremental_refresh_upload_task_service.rb
+++ b/app/services/incremental_refresh_upload_task_service.rb
@@ -8,6 +8,7 @@ class IncrementalRefreshUploadTaskService < TaskService
 
   def process
     @task = IncrementalRefreshUploadTask.create!(task_options)
+    Source.update(source_id, :refresh_started_at => Time.current)
     ActiveRecord::Base.connection().commit_db_transaction unless Rails.env.test?
     self
   end

--- a/app/services/post_persister_task_service.rb
+++ b/app/services/post_persister_task_service.rb
@@ -14,5 +14,6 @@ class PostPersisterTaskService < TaskService
   def update_source
     source = Source.find(@options[:task].source_id)
     source.update!(:last_successful_refresh_at => @options[:task][:input]["refresh_request_at"]) if @options[:task].status == "ok"
+    source.update!(:refresh_finished_at => Time.current)
   end
 end


### PR DESCRIPTION
Set `refresh_started_at` when Upload Task is created.
Set `refresh_finished_at` when Persister Task is complete.