### PR TITLE
Update the Task object if we get error from Cloud Controller

### DIFF
--- a/app/services/mqtt_controller_service.rb
+++ b/app/services/mqtt_controller_service.rb
@@ -15,6 +15,7 @@ class MQTTControllerService
     @task_url = @options[:task_url]
     @mqtt_client_guid = @options[:mqtt_client_guid]
     @mqtt_client_url  = @options[:mqtt_client_url]
+    @task = Task.find(@task_id)
   end
 
   # TODO: will replace by the mqtt controller in cluster
@@ -26,6 +27,8 @@ class MQTTControllerService
   private
 
   def send_to_cloud_controller
+    account = @task.tenant.external_tenant
+    # TODO: Remove account and xrh once Cloud Controller starts getting the account #
     account = "111000"
     x_rh_identity="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWUsImlzX3RyaWFsIjpmYWxzZX0sImNvc3RfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1ZSwiaXNfdHJpYWwiOmZhbHNlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZSwiaXNfdHJpYWwiOmZhbHNlfSwiYW5zaWJsZSI6eyJpc19lbnRpdGxlZCI6dHJ1ZSwiaXNfdHJpYWwiOmZhbHNlfSwidXNlcl9wcmVmZXJlbmNlcyI6eyJpc19lbnRpdGxlZCI6dHJ1ZSwiaXNfdHJpYWwiOmZhbHNlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlLCJpc190cmlhbCI6ZmFsc2V9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlLCJpc190cmlhbCI6ZmFsc2V9LCJzdWJzY3JpcHRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlLCJpc190cmlhbCI6ZmFsc2V9LCJzZXR0aW5ncyI6eyJpc19lbnRpdGxlZCI6dHJ1ZSwiaXNfdHJpYWwiOmZhbHNlfX0sImlkZW50aXR5Ijp7ImludGVybmFsIjp7ImF1dGhfdGltZSI6Nzk5LCJvcmdfaWQiOiIxMTc4OTc3MiJ9LCJhY2NvdW50X251bWJlciI6IjYwODk3MTkiLCJhdXRoX3R5cGUiOiJiYXNpYy1hdXRoIiwidXNlciI6eyJpc19hY3RpdmUiOnRydWUsImxvY2FsZSI6ImVuX1VTIiwiaXNfb3JnX2FkbWluIjp0cnVlLCJ1c2VybmFtZSI6Imluc2lnaHRzLXFhIiwiZW1haWwiOiJkYWpvaG5zb0ByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6Ikluc2lnaHRzIiwidXNlcl9pZCI6IjUxODM0Nzc2IiwibGFzdF9uYW1lIjoiUUEiLCJpc19pbnRlcm5hbCI6dHJ1ZX0sInR5cGUiOiJVc2VyIn19"
     cc_url = File.join(@mqtt_client_url, API_VERSION, "message")
@@ -49,6 +52,7 @@ class MQTTControllerService
 
     Rails.logger.info("Cloud Controller response #{@mqtt_client_guid} #{response.body}")
   rescue => error
+    @task.update_attributes(:state => "completed", :status => "error", :output => {'errors' => ["#{error}"]} )
     Rails.logger.error("Error sending message to cloud controller #{@mqtt_client_guid} #{error}")
   end
 

--- a/spec/services/mqtt_controller_service_spec.rb
+++ b/spec/services/mqtt_controller_service_spec.rb
@@ -2,9 +2,12 @@ describe MQTTControllerService do
   include ::Spec::Support::TenantIdentity
 
   let(:subject) { described_class.new(params) }
+  let(:task) { FactoryBot.create(:task, :source => source, :tenant => tenant) }
+  let(:source) { FactoryBot.create(:source, :enabled => true, :tenant => tenant) }
+  let(:task_id) { task.id }
 
   describe "#initialize" do
-    let(:params) { {"task_id" => "task_id_1", "task_url" => "url", "mqtt_client_url" => "m_url", "mqtt_client_guid" => "guid"} }
+    let(:params) { {"task_id" => task_id, "task_url" => "url", "mqtt_client_url" => "m_url", "mqtt_client_guid" => "guid"} }
 
     it "returns service" do
       expect(subject.class).to eq(MQTTControllerService)
@@ -13,7 +16,7 @@ describe MQTTControllerService do
 
   shared_examples_for "options keys check" do |key|
     context "when options key is missing" do
-      let(:options) { {"task_id" => "task_id_1", "task_url" => "url", "mqtt_client_url" => "m_url", "mqtt_client_guid" => "guid"} }
+      let(:options) { {"task_id" => task_id, "task_url" => "url", "mqtt_client_url" => "m_url", "mqtt_client_guid" => "guid"} }
       let(:params) { options.except(key) }
 
       it "raise exception" do


### PR DESCRIPTION
If the RHCD running on prem can't be reached or the Cloud
Controller itself can't be reached or for any other errors we have
to mark the task as Failed.