### PR TITLE
Remove ACG_CONFIG env variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'activerecord-virtual_attributes', '~> 1.5'
-gem 'app-common-ruby', :git => "https://github.com/RedHatInsights/app-common-ruby", :branch => "master", :require => false
+gem 'app-common-ruby', :git => "https://github.com/hsong-rh/app-common-ruby.git", :branch => "change_clowder_enabled", :require => false
 gem 'cloudwatchlogger',                '~> 0.2.1'
 gem 'insights-api-common',             '~> 5.0.1' 
 gem 'jbuilder',                        '~> 2.0'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,3 @@
-ENV['ACG_CONFIG'] ||= 'cdappconfig.json'
-
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/initializers/clowder_config.rb
+++ b/config/initializers/clowder_config.rb
@@ -6,8 +6,8 @@ class ClowderConfig
 
   def self.instance
     @instance ||= {}.tap do |options|
-      config = AppCommonRuby::Config.load
-      if config.clowder_enabled?
+      if AppCommonRuby::Config.clowder_enabled?
+        config = AppCommonRuby::Config.load
         options["webPorts"] = config.webPort
         options["metricsPort"] = config.metricsPort
         options["metricsPath"] = config.metricsPath

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,6 @@ end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-ENV['ACG_CONFIG'] ||= 'cdappconfig.json'
 ENV['APP_NAME'] = 'catalog-inventory'
 ENV['PATH_PREFIX'] = 'api'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
The app-common-ruby gem has been changed to depend on a single environment variable to check if Clowder Config has been enabled.