### PR TITLE
Removed the temporary account number

### DIFF
--- a/app/services/mqtt_controller_service.rb
+++ b/app/services/mqtt_controller_service.rb
@@ -28,8 +28,6 @@ class MQTTControllerService
 
   def send_to_cloud_controller
     account = @task.tenant.external_tenant
-    # TODO: Remove account once Cloud Controller starts getting the account #
-    account = "111000"
 
     cc_url = File.join(@mqtt_client_url, API_VERSION, "message")
     body = {'account':   account,


### PR DESCRIPTION
We were using a temporary account number till the Cloud Controller
team finished their work on account numbers.