### PR TITLE
Change dependencies to optional

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -86,7 +86,7 @@ objects:
     - replicas: 3
       partitions: 3
       topicName: platform.catalog-inventory.task-output-stream
-    dependencies:
+    optionalDependencies: # temp change to optional
     - ingress
     - sources
     database:


### PR DESCRIPTION
Temp changed dependencies into optional to diagnose the clowder deployment issue