### PR TITLE
Get back last_refresh_message in Source

### DIFF
--- a/app/services/post_persister_task_service.rb
+++ b/app/services/post_persister_task_service.rb
@@ -30,7 +30,7 @@ class PostPersisterTaskService < TaskService
      :previous_sha               => @upload_task.output["sha256"],
      :previous_size              => @upload_task.output["tar_size"],
      :refresh_finished_at        => Time.current,
-     :last_refresh_message       => "Refresh completed",
+     :last_refresh_message       => refresh_stats_message,
      :refresh_state              => "Done"}
   end
 

--- a/spec/services/post_persister_task_service_spec.rb
+++ b/spec/services/post_persister_task_service_spec.rb
@@ -20,7 +20,7 @@ describe PostPersisterTaskService do
       subject.process
 
       source.reload
-      #expect(source.last_refresh_message).to eq(last_refresh_message)
+      expect(source.last_refresh_message).to eq(last_refresh_message)
       expect(source.refresh_state).to eq(refresh_state)
     end
   end


### PR DESCRIPTION
The changes in https://github.com/RedHatInsights/catalog_tower_persister/pull/44 populate `last_refresh_message` with modified data. Update it to Source object.