### PR TITLE
change database name to catalong-inventory in clouwadd.yaml

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -126,7 +126,7 @@ objects:
     - ingress
     - sources
     database:
-      name: catalog_inventory
+      name: catalog-inventory
 
 parameters:
 - name: CURRENT_API_VERSION


### PR DESCRIPTION
The name has to match secret in openshift which does not allow underscore.