### PR TITLE
Add STI task type in json output

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,6 +8,17 @@ class ApplicationRecord < ActiveRecord::Base
     super
   end
 
+  def serializable_hash(options = nil)
+    return super(options) unless has_attribute?(self.class.inheritance_column)
+
+    options = options.try(:dup) || {}
+
+    options[:methods]  = Array(options[:methods]).map(&:to_s)
+    options[:methods] |= Array(self.class.inheritance_column)
+
+    super(options)
+  end
+
   require 'act_as_taggable_on'
   ActiveSupport.on_load(:active_record) do
     extend ActAsTaggableOn

--- a/spec/requests/api/v1.0/tasks_spec.rb
+++ b/spec/requests/api/v1.0/tasks_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe("v1.0 - Task") do
     "tasks",
     [],
   )
+
+  context 'GET /tasks' do
+    around do |example|
+      with_modified_env(:CATALOG_INVENTORY_INTERNAL_URL => "http://inventory.example.com") do
+        example.call
+      end
+    end
+
+    before do
+      source = Source.create!(:name => "foo", :tenant => tenant)
+      FullRefreshUploadTask.create!(:tenant => tenant, :source => source, :state => "pending", :status => "ok")
+      FullRefreshPersisterTask.create!(:tenant => tenant, :source => source, :state => "pending", :status => "ok")
+    end
+
+    it "list all tasks" do
+      get "/api/catalog-inventory/v1.0/tasks", :headers => headers
+
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)["data"].count).to eq(2)
+
+      expect(JSON.parse(response.body)["data"].first["type"]).to eq("FullRefreshPersisterTask")
+      expect(JSON.parse(response.body)["data"].second["type"]).to eq("FullRefreshUploadTask")
+    end
+  end
 end


### PR DESCRIPTION
By default the inherit column in STI does not appear in JSON output. But we need this information to tell us the task type. This PR adds it.