### PR TITLE
Remove the extra service to route port number

### DIFF
--- a/config/initializers/clowder_config.rb
+++ b/config/initializers/clowder_config.rb
@@ -37,7 +37,7 @@ class ClowderConfig
         options["databasePassword"] = config.database.password
 
         options["SOURCES_URL"] = exists("SOURCES_URL", options["endpoints"]["sources-api-svc"])
-        options["CATALOG_INVENTORY_INTERNAL_URL"] = options["endpoints"]["catalog-inventory-api-v2"]
+        options["CATALOG_INVENTORY_INTERNAL_URL"] = options["endpoints"]["catalog-inventory-api"]
       else
         options["webPorts"] = 3000
         options["metricsPort"] = 8080

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -30,7 +30,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     deployments:
-    - name: api-v2
+    - name: api
       minReplicas: ${{MIN_REPLICAS}}
       webServices:
         public:
@@ -143,21 +143,6 @@ objects:
     - sources
     database:
       name: catalog-inventory
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: catalog-inventory-api
-    labels:
-      app: catalog-inventory-api
-      pod: catalog-inventory-api-v2
-  spec:
-    ports:
-    - port: 8080
-      protocol: TCP
-      targetPort: 8000
-      name: weblegacy
-    selector:
-      pod: catalog-inventory-api-v2
 
 parameters:
 - name: CURRENT_API_VERSION


### PR DESCRIPTION
3Scale team has changed the port number from 8080 to 8000. No need to have an extra service to do the switch work. 

https://issues.redhat.com/browse/RHCLOUD-13889