### PR TITLE
Fix source refresh failure in callback method

### DIFF
--- a/app/models/incremental_refresh_upload_task.rb
+++ b/app/models/incremental_refresh_upload_task.rb
@@ -1,5 +1,5 @@
 class IncrementalRefreshUploadTask < CloudConnectorTask
-  after_update_commit :post_upload_task, :if => proc { state == 'completed' && (status == 'unchanged' || status == 'error') }
+  after_update_commit :post_upload_task, :if => proc { saved_change_to_state?(:to => 'completed') && ['unchanged', 'error', 'ok'].include?(status) }
 
   @timeout_interval = ClowderConfig.instance["SOURCE_REFRESH_TIMEOUT"] * 60 # in seconds
 


### PR DESCRIPTION
Fix to add `ok` in the status list to trigger callback service.

https://issues.redhat.com/browse/SSP-2354